### PR TITLE
Make the sort order of stations consistent

### DIFF
--- a/src/app/components/bootstrap.tsx
+++ b/src/app/components/bootstrap.tsx
@@ -27,7 +27,13 @@ const Bootsrap: React.FC = () => {
           console.error("Failed to add frequency", freq, station);
           return;
         }
-        useRadioState.getState().addRadio(freq, station);
+        useRadioState
+          .getState()
+          .addRadio(
+            freq,
+            station,
+            useSessionStore.getState().getStationCallsign()
+          );
         window.api.SetRadioGain(useSessionStore.getState().radioGain / 100);
       });
     });
@@ -37,7 +43,9 @@ const Bootsrap: React.FC = () => {
     });
 
     window.api.on("StationRxBegin", (frequency, callsign) => {
-      useRadioState.getState().setLastReceivedCallsign(parseInt(frequency), callsign);
+      useRadioState
+        .getState()
+        .setLastReceivedCallsign(parseInt(frequency), callsign);
     });
 
     window.api.on("FrequencyRxEnd", (frequency) => {

--- a/src/app/components/sidebar/add-frequency.tsx
+++ b/src/app/components/sidebar/add-frequency.tsx
@@ -10,7 +10,9 @@ const AddFrequency: React.FC = () => {
     state.setRx,
   ]);
 
-  const isNetworkConnected = useSessionStore((state) => state.isNetworkConnected);
+  const isNetworkConnected = useSessionStore(
+    (state) => state.isNetworkConnected
+  );
 
   const addFrequency = () => {
     if (!readyToAdd) {
@@ -29,7 +31,11 @@ const AddFrequency: React.FC = () => {
       if (!ret) {
         return; // This will check if the frequency exists and send an error message already
       }
-      addRadio(frequencyInHz, "MANUAL");
+      addRadio(
+        frequencyInHz,
+        "MANUAL",
+        useSessionStore.getState().getStationCallsign()
+      );
       setRx(frequencyInHz, true);
     });
 

--- a/src/app/helpers/CallsignHelper.ts
+++ b/src/app/helpers/CallsignHelper.ts
@@ -7,10 +7,10 @@ export const getCleanCallsign = (callsign: string): string => {
 };
 
 /**
- * Takes a callsign like ZOA-ZSE, SEA_GND, or SEA_W_TWR and returns the three separate parts:
- * Station: SEA (or original callsign if no parts found)
+ * Takes a callsign like ZOA-ZSE, SEA_GND, or LFPG_N_TWR and returns the three separate parts:
+ * Station: LFPG (or original callsign if no parts found)
  * Position: TWR (or empty string if no position found)
- * Subposition: W (or empty string if no sub-position found)
+ * Subposition: N (or empty string if no sub-position found)
  * @param callsign The callsign to split apart
  * @returns An array of the three parts: [station, position, subPosition]
  */
@@ -29,6 +29,6 @@ export const getCallsignParts = (
     return [parts[0], "", parts[1]];
   }
 
-  // Handles cases like "SEA_W_TWR"
+  // Handles cases like "LFPG_N_TWR"
   return [parts[0], parts[2], parts[1]];
 };

--- a/src/app/helpers/CallsignHelper.ts
+++ b/src/app/helpers/CallsignHelper.ts
@@ -1,7 +1,34 @@
 export const checkIfCallsignIsRelief = (callsign: string): boolean => {
-    return callsign.includes("_1_") || callsign.includes("__");
+  return callsign.includes("_1_") || callsign.includes("__");
 };
 
 export const getCleanCallsign = (callsign: string): string => {
-    return callsign.replace("_1_", "_").replace("__", "_");
+  return callsign.replace("_1_", "_").replace("__", "_");
+};
+
+/**
+ * Takes a callsign like ZOA-ZSE, SEA_GND, or SEA_W_TWR and returns the three separate parts:
+ * Station: SEA (or original callsign if no parts found)
+ * Position: TWR (or empty string if no position found)
+ * Subposition: W (or empty string if no sub-position found)
+ * @param callsign The callsign to split apart
+ * @returns An array of the three parts: [station, position, subPosition]
+ */
+export const getCallsignParts = (
+  callsign: string
+): [string, string, string] => {
+  const parts = callsign.split("_");
+
+  // Handles cases like "ZOA-ZSE"
+  if (parts.length === 1) {
+    return [callsign, "", ""];
+  }
+
+  // Handles cases like "SEA_GND"
+  if (parts.length === 2) {
+    return [parts[0], "", parts[1]];
+  }
+
+  // Handles cases like "SEA_W_TWR"
+  return [parts[0], parts[2], parts[1]];
 };

--- a/src/app/helpers/RadioHelper.ts
+++ b/src/app/helpers/RadioHelper.ts
@@ -3,8 +3,8 @@ import { RadioType } from "../store/radioStore";
 /**
  * Compares two radios to determine sort order. The currently connected station
  * will always sort to the front of the list. The remaining stations will sort
- * by station name (e.g. "SEA"), then by position (e.g. "TWR"), then by
- * sub-position (e.g. "E")
+ * by station name (e.g. "LFPG"), then by position (e.g. "TWR"), then by
+ * sub-position (e.g. "N")
  * @param a The first radio to compare
  * @param b The second radio to compare
  * @param connectedStationCallsign The callsign for the connected station

--- a/src/app/helpers/RadioHelper.ts
+++ b/src/app/helpers/RadioHelper.ts
@@ -1,0 +1,32 @@
+import { RadioType } from "../store/radioStore";
+
+/**
+ * Compares two radios to determine sort order. The currently connected station
+ * will always sort to the front of the list. The remaining stations will sort
+ * by station name (e.g. "SEA"), then by position (e.g. "TWR"), then by
+ * sub-position (e.g. "E")
+ * @param a The first radio to compare
+ * @param b The second radio to compare
+ * @param connectedStationCallsign The callsign for the connected station
+ * @returns -1 if a comes before b. 1 if b comes before a.
+ */
+export const radioCompare = (
+  a: RadioType,
+  b: RadioType,
+  connectedStationCallsign: string
+): number => {
+  // The connected station always get sorted to the front of the list.
+  if (a.callsign === connectedStationCallsign) return -1;
+  if (b.callsign === connectedStationCallsign) return 1;
+
+  // The station name takes sort priority
+  const stationComparison = a.station.localeCompare(b.station);
+  if (stationComparison !== 0) return stationComparison;
+
+  // Subsort by position name if the station name is the same
+  const positionComparison = a.position.localeCompare(b.position);
+  if (positionComparison !== 0) return positionComparison;
+
+  // Subsort by sub-position name if the position is the same
+  return a.subPosition.localeCompare(b.subPosition);
+};


### PR DESCRIPTION
Fixes #12

Draft pull request with the initial work for feedback. Summary of changes:

1. Add a new `RadioHelper.ts` file that includes a `radioCompare` method to compare two radios for sorting
2. Add a new `getCallsignParts` method that takes a callsign and splits it out into the station, position, and subposition
3. Add new `station`, `position`, and `subPosition` properties on a radio and set them when radios are added. These are used for sorting later
4.  Pass the connected station callsign through when adding radios

The sorting winds up being a bit of a pain to make things look right in the list. Here's the logic:

1. The connected station always goes to the front of the list
2. Remaining stations are sorted by station name, then by position, then by sub-position (if any)

In my playing around this seems to work well and makes for a sensible list.

I'm not a huge fan of passing through the connected station callsign to the addRadios method but I didn't see another way to do it without taking a dependency on `useSessionState` inside `useRadioState` which seemed bad. Let me know if you have other ideas here.

Untested (and likely not working) is sorting the connected callsign to the front of the list when connected via a relief position (e.g. SEA_1_GND). I think the way to resolve that is to actually store the cleaned connected station callsign in session state as well (so it doesn't keep getting computed), and use that instead of the regular station callsign in the sort method.