### PR TITLE
Stations without a subposition don't sort properly

### DIFF
--- a/src/app/helpers/CallsignHelper.ts
+++ b/src/app/helpers/CallsignHelper.ts
@@ -26,7 +26,7 @@ export const getCallsignParts = (
 
   // Handles cases like "SEA_GND"
   if (parts.length === 2) {
-    return [parts[0], "", parts[1]];
+    return [parts[0], parts[1], ""];
   }
 
   // Handles cases like "LFPG_N_TWR"


### PR DESCRIPTION
Fixes #21

Change the order of the empty sub-position string in the return from `getCallsignParts`.

After the fix:

![image](https://github.com/pierr3/TrackAudio/assets/9524118/e10d4d8f-eab4-4cfe-9cd3-b4c7e79f6beb)
