### PR TITLE
Show empty received radios in mini view

### DIFF
--- a/src/app/components/mini.tsx
+++ b/src/app/components/mini.tsx
@@ -7,14 +7,15 @@ const Mini: React.FC = () => {
   return (
     <div className="box-container mini">
       <div className="container">
-        {radios.filter((r) => r.lastReceivedCallsign).map((radio) => {
+        {radios.map((radio) => {
           if (radio.rx) {
             return (
               <div
                 key={radio.frequency}
                 style={{ color: radio.currentlyTx ? "orange" : "inherit" }}
               >
-                {radio.callsign}: {radio.lastReceivedCallsign}
+                {radio.callsign}:{" "}
+                {radio.lastReceivedCallsign ? radio.lastReceivedCallsign : ""}
               </div>
             );
           }


### PR DESCRIPTION
Fixes #20

Show an empty string (to match how "Last RX" is displayed in the larger view) for radios that haven't received a transmission yet.

I have no idea why I suggested the more complicated way to fix this. This way is so simple.

With this change, before any transmissions:

![image](https://github.com/pierr3/TrackAudio/assets/9524118/ad7f0678-1823-4ee9-bc6d-68975c3dc522)

With this change, after a transmission:

![image](https://github.com/pierr3/TrackAudio/assets/9524118/83eb5998-1ba3-4f18-823d-c61c065a0afc)
