### PR TITLE
Show active receive in the mini view

### DIFF
--- a/src/app/components/mini.tsx
+++ b/src/app/components/mini.tsx
@@ -19,7 +19,7 @@ const Mini: React.FC = () => {
                 </span>
                 :{" "}
                 <span
-                  style={{ color: radio.currentlyRx ? "orange" : "inherit" }}
+                  style={{ color: radio.currentlyRx ? "green" : "inherit" }}
                 >
                   {radio.lastReceivedCallsign ? radio.lastReceivedCallsign : ""}
                 </span>

--- a/src/app/components/mini.tsx
+++ b/src/app/components/mini.tsx
@@ -7,17 +7,25 @@ const Mini: React.FC = () => {
   return (
     <div className="box-container mini">
       <div className="container">
-        {radios.filter((r) => r.rx).map((radio) => {
+        {radios
+          .filter((r) => r.rx)
+          .map((radio) => {
             return (
-              <div
-                key={radio.frequency}
-                style={{ color: radio.currentlyTx ? "orange" : "inherit" }}
-              >
-                {radio.callsign}:{" "}
-                {radio.lastReceivedCallsign ? radio.lastReceivedCallsign : ""}
+              <div key={radio.frequency}>
+                <span
+                  style={{ color: radio.currentlyTx ? "orange" : "inherit" }}
+                >
+                  {radio.callsign}
+                </span>
+                :{" "}
+                <span
+                  style={{ color: radio.currentlyRx ? "orange" : "inherit" }}
+                >
+                  {radio.lastReceivedCallsign ? radio.lastReceivedCallsign : ""}
+                </span>
               </div>
             );
-        })}
+          })}
       </div>
     </div>
   );


### PR DESCRIPTION
Fixes #24

Highlights the station name on Tx:

<img width="132" alt="image" src="https://github.com/pierr3/TrackAudio/assets/9524118/46c7934d-29ae-4555-9020-4b95b4792eea">

And the callsign on Rx:

<img width="128" alt="image" src="https://github.com/pierr3/TrackAudio/assets/9524118/24f4c883-8eb3-4c9d-8a00-b1ead2da754c">
