### PR TITLE
Add vscode debug configuration

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,36 @@
+{
+  // Use IntelliSense to learn about possible attributes.
+  // Hover to view descriptions of existing attributes.
+  // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "type": "node",
+      "request": "launch",
+      "name": "Electron: Main",
+      "runtimeExecutable": "${workspaceFolder}/node_modules/@electron-forge/cli/script/vscode.sh",
+      "runtimeArgs": ["--remote-debugging-port=9223"],
+      "windows": {
+        "runtimeExecutable": "${workspaceFolder}/node_modules/@electron-forge/cli/script/vscode.cmd"
+      },
+      "cwd": "${workspaceFolder}",
+      "console": "integratedTerminal"
+    },
+    {
+      "name": "Electron: Renderer",
+      "type": "chrome",
+      "request": "attach",
+      "port": 9223,
+      "webRoot": "${workspaceFolder}",
+      "timeout": 30000,
+    }],
+    "compounds": [
+      {
+          "name": "Electron: All",
+          "configurations": [
+              "Electron: Main",
+              "Electron: Renderer"
+          ]
+      }
+  ]
+}


### PR DESCRIPTION
Fixes #26

Adds a launch.json to enable debugging both the main and the rendering process.

![image](https://github.com/pierr3/TrackAudio/assets/9524118/2858453b-acfe-4df3-9a75-380b22b0bd2e)

Here is a breakpoint getting hit in the main process:

![image](https://github.com/pierr3/TrackAudio/assets/9524118/f9b2aab1-bfae-4c8e-81e6-80ef4f27c4b2)

And here's one getting hit in the rendering process:

![image](https://github.com/pierr3/TrackAudio/assets/9524118/df8da293-877d-43fe-bab2-f69edd43dc01)
 