### PR TITLE
Edit README to include newly created Homebrew tap

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ Alternatively, TrackAudio can be installed using [Homebrew](https://brew.sh/inde
 brew tap flymia/homebrew-trackaudio
 
 # Install the cask
-brew install --cask vectoraudio
+brew install --cask trackaudio
 ```
 
 Depending on your system, the cask will install the ARM version or the x86_64 version.

--- a/README.md
+++ b/README.md
@@ -94,6 +94,18 @@ Download the latest release on the [release page](https://github.com/pierr3/Trac
 
 TrackAudio is available in two versions, one for apple silicon (arm64) and one for intel macs (x64).
 
+Alternatively, TrackAudio can be installed using [Homebrew](https://brew.sh/index). Run the following commands to first install the Homebrew Tap and then the Homebrew Cask. This way the app gets upgraded when you run `brew upgrade`.
+
+```sh
+# Add the tap
+brew tap flymia/homebrew-trackaudio
+
+# Install the cask
+brew install --cask vectoraudio
+```
+
+Depending on your system, the cask will install the ARM version or the x86_64 version.
+
 ### Windows
 
 Download the latest release on the [release page](https://github.com/pierr3/TrackAudio/releases) and run the executable. This should install TrackAudio.


### PR DESCRIPTION
I created a Homebrew tap for macOS users, which let's them install TrackAudio easily by using a terminal command. The advantage of this is, that TrackAudio is easily patched using `brew upgrade`. I already did this for VectorAudio two years ago and would love to support the Homebrew tap again, this time for TrackAudio.

This PR adds the instructions in the README for installing TrackAudio using homebrew. The homebrew cask respects the architecture and selects the release correctly depending on the system you are using.