### PR TITLE
Fix restoring from mini mode on Windows

### DIFF
--- a/src/app/style/app.scss
+++ b/src/app/style/app.scss
@@ -238,6 +238,8 @@ button:disabled {
   padding-right: 0;
 }
 
+// When changing the max-width property make sure to update the miniModeWidthBreakpoint constant in
+// the toggleMiniMode method in index.ts as well.
 @media only screen and (max-width: 300px) {
   .freq-box {
     display: none;
@@ -383,12 +385,16 @@ select:disabled {
   font-size: $mini-font-size;
 }
 
+// When changing the max-width property make sure to update the miniModeWidthBreakpoint constant in
+// the toggleMiniMode method in index.ts as well.
 @media only screen and (max-width: 300px) {
   .mini {
     display: block;
   }
 }
 
+// When changing the max-width property make sure to update the miniModeWidthBreakpoint constant in
+// the toggleMiniMode method in index.ts as well.
 @media only screen and (max-width: 300px) {
   .hide-topbar {
     display: none !important;

--- a/src/index.ts
+++ b/src/index.ts
@@ -60,16 +60,22 @@ const setAudioSettings = () => {
 };
 
 const toggleMiniMode = () => {
-  if (
-    mainWindow.getSize()[0] == mainWindow.getMinimumSize()[0] &&
-    mainWindow.getSize()[1] == mainWindow.getMinimumSize()[1]
-  ) {
+  // Issue 79: Use the size of the content and the width breakpoint for mini-mode
+  // to determine whether to restore from mini-mode. This solves an issue where
+  // getSize() was returning a width value off by one from the getMinSize()
+  // call.
+  if (mainWindow.getContentSize()[0] <= 300) {
     mainWindow.setSize(savedLastWindowSize.width, savedLastWindowSize.height);
     return;
   }
   savedLastWindowSize.width = mainWindow.getSize()[0];
   savedLastWindowSize.height = mainWindow.getSize()[1];
-  mainWindow.setSize(1, 1);
+
+  // Issue 79: Use the width breakpoint for the width instead of setting to 1
+  // so the window doesn't go as small as possible when put in mini-mode. This
+  // makes toggling work properly when using 300 as the value for determining when
+  // to switch to big mode.
+  mainWindow.setSize(300, 1);
 };
 
 const restoreWindowBounds = (win: BrowserWindow) => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -60,11 +60,13 @@ const setAudioSettings = () => {
 };
 
 const toggleMiniMode = () => {
+  const miniModeWidthBreakpoint = 300;
+
   // Issue 79: Use the size of the content and the width breakpoint for mini-mode
   // to determine whether to restore from mini-mode. This solves an issue where
   // getSize() was returning a width value off by one from the getMinSize()
   // call.
-  if (mainWindow.getContentSize()[0] <= 300) {
+  if (mainWindow.getContentSize()[0] <= miniModeWidthBreakpoint) {
     mainWindow.setSize(savedLastWindowSize.width, savedLastWindowSize.height);
     return;
   }
@@ -75,7 +77,7 @@ const toggleMiniMode = () => {
   // so the window doesn't go as small as possible when put in mini-mode. This
   // makes toggling work properly when using 300 as the value for determining when
   // to switch to big mode.
-  mainWindow.setSize(300, 1);
+  mainWindow.setSize(miniModeWidthBreakpoint, 1);
 };
 
 const restoreWindowBounds = (win: BrowserWindow) => {


### PR DESCRIPTION
Fixes #79

* Use `getContentSize()` and a fixed 300-pixel width as the test for whether to restore from mini-mode

I'm not wild about the hardcoded `300` value but making it a .scss variable and then reading that at runtime would require far more extensive changes that don't seem worth it.