### PR TITLE
Enable switching to mini-mode when window is maximized

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -70,6 +70,13 @@ const toggleMiniMode = () => {
     mainWindow.setSize(savedLastWindowSize.width, savedLastWindowSize.height);
     return;
   }
+
+  // Issue 84: If the window is maximized it has to be unmaximized before
+  // setting the window size to mini-mode otherwise nothing happens.
+  if (mainWindow.isMaximized()) {
+    mainWindow.unmaximize();
+  }
+
   savedLastWindowSize.width = mainWindow.getSize()[0];
   savedLastWindowSize.height = mainWindow.getSize()[1];
 


### PR DESCRIPTION
Fixes #84

* Add a test for the window being maximized, and un-maximize before setting the window to mini-mode