### PR TITLE
Add an "in mini mode" option for always on top

### DIFF
--- a/src/main/config.d.ts
+++ b/src/main/config.d.ts
@@ -1,3 +1,5 @@
+export type AlwaysOnTopMode = 'never' | 'always' | 'inMiniMode';
+
 export interface Configuration {
   audioApi: number;
   audioInputDeviceId: string;
@@ -11,6 +13,7 @@ export interface Configuration {
   hardwareType: number;
   radioGain: number;
 
-  alwaysOnTop: boolean;
+  // Boolean is the prior type for this property, AlwaysOnTopMode is the updated type.
+  alwaysOnTop: boolean | AlwaysOnTopMode;
   consentedToTelemetry: boolean | undefined;
 }

--- a/src/preload/bindings.ts
+++ b/src/preload/bindings.ts
@@ -1,4 +1,5 @@
 import { ipcRenderer, IpcRendererEvent } from 'electron';
+import { AlwaysOnTopMode } from '../main/config';
 
 export const api = {
   /* eslint-disable  @typescript-eslint/no-explicit-any */
@@ -12,7 +13,7 @@ export const api = {
     ipcRenderer.removeAllListeners(channel);
   },
 
-  setAlwaysOnTop: (state: boolean) => {
+  setAlwaysOnTop: (state: AlwaysOnTopMode) => {
     ipcRenderer.send('set-always-on-top', state);
   },
   getAudioApis: () => ipcRenderer.invoke('audio-get-apis'),

--- a/src/renderer/src/components/settings-modal/settings-modal.tsx
+++ b/src/renderer/src/components/settings-modal/settings-modal.tsx
@@ -5,7 +5,7 @@ import AudioOutputs from './audio-outputs';
 import useUtilStore from '../../store/utilStore';
 import clsx from 'clsx';
 import { useDebouncedCallback } from 'use-debounce';
-import { Configuration } from '../../../../../src/main/config';
+import { AlwaysOnTopMode, Configuration } from '../../../../../src/main/config';
 import { AudioApi, AudioDevice } from 'trackaudio-afv';
 import useRadioState from '../../store/radioStore';
 
@@ -26,7 +26,7 @@ const SettingsModal: React.FC<SettingsModalProps> = ({ closeModal }) => {
   const [audioInputDevices, setAudioInputDevices] = useState(Array<AudioDevice>);
   const [hardwareType, setHardwareType] = useState(0);
   const [config, setConfig] = useState({} as Configuration);
-  const [alwaysOnTop, setAlwaysOnTop] = useState(0);
+  const [alwaysOnTop, setAlwaysOnTop] = useState<AlwaysOnTopMode>('never');
 
   const [cid, setCid] = useState('');
   const [password, setPassword] = useState('');
@@ -52,7 +52,7 @@ const SettingsModal: React.FC<SettingsModalProps> = ({ closeModal }) => {
         setCid(config.cid || '');
         setPassword(config.password || '');
         setHardwareType(config.hardwareType || 0);
-        setAlwaysOnTop(config.alwaysOnTop ? 1 : 0);
+        setAlwaysOnTop(config.alwaysOnTop as AlwaysOnTopMode); // Type assertion since the config will never be a boolean at this point
       })
       .catch((err: unknown) => {
         console.error(err);
@@ -148,8 +148,8 @@ const SettingsModal: React.FC<SettingsModalProps> = ({ closeModal }) => {
 
   const handleAlwaysOnTop = (e: React.ChangeEvent<HTMLSelectElement>) => {
     setChangesSaved(SaveStatus.Saving);
-    window.api.setAlwaysOnTop(e.target.value === '1');
-    setAlwaysOnTop(parseInt(e.target.value));
+    window.api.setAlwaysOnTop(e.target.value as AlwaysOnTopMode);
+    setAlwaysOnTop(e.target.value as AlwaysOnTopMode);
     setChangesSaved(SaveStatus.Saved);
   };
 
@@ -251,8 +251,9 @@ const SettingsModal: React.FC<SettingsModalProps> = ({ closeModal }) => {
                     onChange={handleAlwaysOnTop}
                     value={alwaysOnTop}
                   >
-                    <option value="1">Yes</option>
-                    <option value="0">No</option>
+                    <option value="always">Always</option>
+                    <option value="inMiniMode">In mini mode</option>
+                    <option value="never">Never</option>
                   </select>
 
                   <label className="mt-2" style={{ fontSize: '10px' }}>


### PR DESCRIPTION
Fixes #113

* Change the always on top setting from a boolean to a list of valid options: `always`, `never` and `inMiniMode`
* Use the setting to determine whether always on top should be set when entering/leaving mini mode
* Handle upgrading prior versions that used a boolean value
* Fix a few places where the always on top fix for Windows wasn't properly applied

New dropdown in settings looks like this:

![image](https://github.com/pierr3/TrackAudio/assets/9524118/3d746b97-ec59-4112-b8fe-fc7c79778af8)
