### PR TITLE
Remove bytecode compilation

### DIFF
--- a/electron.vite.config.ts
+++ b/electron.vite.config.ts
@@ -1,13 +1,13 @@
 import { resolve } from 'path';
-import { defineConfig, externalizeDepsPlugin, bytecodePlugin } from 'electron-vite';
+import { defineConfig, externalizeDepsPlugin } from 'electron-vite';
 import react from '@vitejs/plugin-react';
 
 export default defineConfig({
   main: {
-    plugins: [externalizeDepsPlugin(), bytecodePlugin()]
+    plugins: [externalizeDepsPlugin()]
   },
   preload: {
-    plugins: [externalizeDepsPlugin(), bytecodePlugin()]
+    plugins: [externalizeDepsPlugin()]
   },
   renderer: {
     resolve: {


### PR DESCRIPTION
For some reason, this breaks the Mac x64 application. We also don't particularly need it, as the performance benefit is minimal, and our application is open-source and doesn't need source protection.

Tested live at FSExpo (thanks Colton!) on an Intel Mac.