### PR TITLE
Ensure CID always shows as a number

### DIFF
--- a/src/renderer/src/components/settings-modal/settings-modal.tsx
+++ b/src/renderer/src/components/settings-modal/settings-modal.tsx
@@ -1,13 +1,13 @@
+import clsx from 'clsx';
 import React, { useEffect, useState } from 'react';
+import { AudioApi, AudioDevice } from 'trackaudio-afv';
+import { useDebouncedCallback } from 'use-debounce';
+import { AlwaysOnTopMode, Configuration } from '../../../../../src/main/config';
+import useRadioState from '../../store/radioStore';
+import useUtilStore from '../../store/utilStore';
 import AudioApis from './audio-apis';
 import AudioInput from './audio-input';
 import AudioOutputs from './audio-outputs';
-import useUtilStore from '../../store/utilStore';
-import clsx from 'clsx';
-import { useDebouncedCallback } from 'use-debounce';
-import { AlwaysOnTopMode, Configuration } from '../../../../../src/main/config';
-import { AudioApi, AudioDevice } from 'trackaudio-afv';
-import useRadioState from '../../store/radioStore';
 
 export interface SettingsModalProps {
   closeModal: () => void;
@@ -88,7 +88,6 @@ const SettingsModal: React.FC<SettingsModalProps> = ({ closeModal }) => {
 
   const debouncedCid = useDebouncedCallback((cid: string) => {
     setChangesSaved(SaveStatus.Saving);
-    setCid(cid);
     setConfig({ ...config, cid: cid });
     void window.api.setCid(cid);
     setChangesSaved(SaveStatus.Saved);
@@ -207,12 +206,16 @@ const SettingsModal: React.FC<SettingsModalProps> = ({ closeModal }) => {
                   <h5>VATSIM Details</h5>
                   <label className="mt-2">CID</label>
                   <input
-                    type="number"
                     className="form-control mt-1"
                     id="cidInput"
                     placeholder="99999"
-                    defaultValue={cid}
-                    onChange={(e) => debouncedCid(e.target.value)}
+                    value={cid}
+                    onChange={(e) => {
+                      // Issue #127: Strip non-digit characters instead of using type="number".
+                      const cleanCid = e.target.value.replace(/\D/g, ''); // Remove non-digit characters
+                      setCid(cleanCid);
+                      debouncedCid(cleanCid);
+                    }}
                   ></input>
                   <label className="mt-2">Password</label>
                   <input


### PR DESCRIPTION
Fixes #127

* Change the input field type to text instead of `number`
* Make the input field controlled
* Strip any non-digit characters from the input

I have no idea if this is actually the fix for the problem since I can't reproduce it. However, this was the only place in the code that attempted to treat the value as a number, so it's possible the browser happened to try and display it in scientific notation for some reason.

Tested on Windows that I can still type digits in, use the backspace key, and paste in a CID without issue. Any non-digit characters simply don't appear.