### PR TITLE
Fix audio issues on Windows, properly handle default config values

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -23,7 +23,9 @@ const defaultWindowSize = { width: 800, height: 660 };
 const miniModeWidthBreakpoint = 330; // This must match the value for $mini-mode-width-breakpoint in variables.scss.
 const defaultMiniModeWidth = 300; // Default width to use for mini mode if the user hasn't explicitly resized it to something else.
 
-let currentConfiguration: Configuration = {
+// Default application configuration. Used as a fallback when any of the properties
+// are missing from the saved configuration.
+const defaultConfiguration = {
   audioApi: -1,
   audioInputDeviceId: '',
   headsetOutputDeviceId: '',
@@ -36,6 +38,9 @@ let currentConfiguration: Configuration = {
   alwaysOnTop: 'never',
   consentedToTelemetry: undefined
 };
+
+let currentConfiguration: Configuration;
+
 const store = new Store();
 
 /**
@@ -69,12 +74,12 @@ const saveConfig = () => {
 
 const setAudioSettings = () => {
   TrackAudioAfv.SetAudioSettings(
-    currentConfiguration.audioApi || -1,
-    currentConfiguration.audioInputDeviceId || '',
-    currentConfiguration.headsetOutputDeviceId || '',
-    currentConfiguration.speakerOutputDeviceId || ''
+    currentConfiguration.audioApi,
+    currentConfiguration.audioInputDeviceId,
+    currentConfiguration.headsetOutputDeviceId,
+    currentConfiguration.speakerOutputDeviceId
   );
-  TrackAudioAfv.SetHardwareType(currentConfiguration.hardwareType || 0);
+  TrackAudioAfv.SetHardwareType(currentConfiguration.hardwareType);
 };
 
 /**
@@ -239,8 +244,19 @@ app.whenReady().then(() => {
   app.on('browser-window-created', (_, window) => {
     optimizer.watchWindowShortcuts(window);
   });
-  // load the configuration
-  currentConfiguration = JSON.parse(store.get('configuration', '{}') as string) as Configuration;
+
+  // Load the saved configuration. This may be missing properties, typically because there was no
+  // saved configuration.
+  const storedConfiguration = JSON.parse(
+    store.get('configuration', '{}') as string
+  ) as Configuration;
+
+  // Apply the default configuration then override the defaults with any saved configuration
+  // values. Spread operator is the best operator.
+  currentConfiguration = {
+    ...defaultConfiguration,
+    ...storedConfiguration
+  };
 
   // Upgrade the alwaysOnTop property from yes/no to the three mode version
   if (typeof currentConfiguration.alwaysOnTop === 'boolean') {

--- a/src/renderer/src/components/settings-modal/settings-modal.tsx
+++ b/src/renderer/src/components/settings-modal/settings-modal.tsx
@@ -49,9 +49,9 @@ const SettingsModal: React.FC<SettingsModalProps> = ({ closeModal }) => {
       .getConfig()
       .then((config: Configuration) => {
         setConfig(config);
-        setCid(config.cid || '');
-        setPassword(config.password || '');
-        setHardwareType(config.hardwareType || 0);
+        setCid(config.cid);
+        setPassword(config.password);
+        setHardwareType(config.hardwareType);
         setAlwaysOnTop(config.alwaysOnTop as AlwaysOnTopMode); // Type assertion since the config will never be a boolean at this point
       })
       .catch((err: unknown) => {
@@ -68,7 +68,7 @@ const SettingsModal: React.FC<SettingsModalProps> = ({ closeModal }) => {
       });
 
     window.api
-      .getAudioOutputDevices(config.audioApi || -1)
+      .getAudioOutputDevices(config.audioApi)
       .then((devices: AudioDevice[]) => {
         setAudioOutputDevices(devices);
       })
@@ -77,7 +77,7 @@ const SettingsModal: React.FC<SettingsModalProps> = ({ closeModal }) => {
       });
 
     window.api
-      .getAudioInputDevices(config.audioApi || -1)
+      .getAudioInputDevices(config.audioApi)
       .then((devices: AudioDevice[]) => {
         setAudioInputDevices(devices);
       })


### PR DESCRIPTION
I'm lucky, on Windows my `audioApi` value is `0`. This exposed a host of problems in the code that tested the value of `audioApi` using logical or. This resulted in a default value of `-1` being used when calling afv-native, and basically broke all audio.

Changes:

* Create a new `defaultConfiguration` object that defines the default value for all configuration properties
* When reading a saved configuration from storage first apply the default configuration, then apply the saved values. This ensure the `currentConfiguration` object always has a value for all the properties, even if it's first run of the app or one of the properties was manually deleted from the saved config.
* Remove places in the code that used `||` as a method of catching undefined/invalid configuration values since that can't happen anymore

Verified on Windows the following works:

1. Deleting the `audioApi` property from a config file
2. Selecting an audio API in settings after running with the value missing from the saved config. Result is the UI magically updates and properly shows the saved output and input devices. Yay.
3. Rx works, tested via listening to KPDX_ATIS in an OBS session