### PR TITLE
Add additional linting, fix reported errors

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -6,7 +6,9 @@ import tseslint from 'typescript-eslint';
 export default [
   {
     files: ['src/**/*.{tsx,ts,js,jsx}'],
-    languageOptions: { globals: { ...globals.browser, ...globals.node } }
+    languageOptions: {
+      globals: { ...globals.browser, ...globals.node }
+    }
   },
   {
     ignores: [
@@ -24,11 +26,22 @@ export default [
       'tests/**/*',
       'mocks/**/*',
       'docs/**/*',
-      '*-config.js'
+      '*-config.js',
+      'eslint.config.mjs'
     ]
   },
   pluginJs.configs.recommended,
-  ...tseslint.configs.recommended,
+  ...tseslint.configs.recommendedTypeChecked,
+  ...tseslint.configs.stylisticTypeChecked,
+  ...tseslint.configs.strictTypeChecked,
+  {
+    languageOptions: {
+      parserOptions: {
+        tsconfigRootDir: import.meta.dirname,
+        project: ['./tsconfig.web.json', './tsconfig.node.json']
+      }
+    }
+  },
   pluginReactConfig,
   {
     settings: { react: { version: 'detect' } },

--- a/src/preload/bindings.ts
+++ b/src/preload/bindings.ts
@@ -6,6 +6,7 @@ export const api = {
   on: (channel: string, listener: (...args: any[]) => void) => {
     /* eslint-disable  @typescript-eslint/no-explicit-any */
     ipcRenderer.on(channel, (_event: IpcRendererEvent, ...args: any[]) => {
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
       listener(...args);
     });
   },

--- a/src/renderer/src/app.tsx
+++ b/src/renderer/src/app.tsx
@@ -48,7 +48,9 @@ function App() {
 const rootElement = document.getElementById('root');
 
 if (rootElement) {
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-call
   const root = createRoot(rootElement);
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
   root.render(<App />);
 } else {
   console.error("Could not find element with id 'root'");

--- a/src/renderer/src/components/error.tsx
+++ b/src/renderer/src/components/error.tsx
@@ -4,11 +4,12 @@ import useErrorStore from '../store/errorStore';
 import useSound from 'use-sound';
 
 // @ts-expect-error idk this is weird
-import errorSfx from "../assets/md80_error.mp3";
+import errorSfx from '../assets/md80_error.mp3';
 
 const ErrorDialog: React.FC = () => {
   const errorStore = useErrorStore((state) => state);
 
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
   const [play] = useSound(errorSfx);
 
   useEffect(() => {

--- a/src/renderer/src/components/sidebar/lastReceivedCallsigns.tsx
+++ b/src/renderer/src/components/sidebar/lastReceivedCallsigns.tsx
@@ -1,9 +1,9 @@
 import { RadioType } from '@renderer/store/radioStore';
 import React, { useMemo } from 'react';
 
-type LastReceivedCallsignsProps = {
+interface LastReceivedCallsignsProps {
   radios: RadioType[];
-};
+}
 
 const LastReceivedCallsigns: React.FC<LastReceivedCallsignsProps> = ({ radios }) => {
   const rxRadios = useMemo(() => {

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -4,6 +4,7 @@
   "compilerOptions": {
     "sourceMap": true,
     "composite": true,
+    "strictNullChecks": true,
     "types": ["electron-vite/node"]
   }
 }

--- a/tsconfig.web.json
+++ b/tsconfig.web.json
@@ -11,6 +11,7 @@
     "allowImportingTsExtensions": true,
     "noEmit": true,
     "composite": true,
+    "strictNullChecks": true,
     "baseUrl": ".",
     "paths": {
       "@renderer/*": [


### PR DESCRIPTION
Fixes #134

Enables the following rules and `strictNullChecks`:

* recommendedTypeChecked
* stylisticTypeChecked
* strictTypeChecked

Also fixes all errors thrown by the new rules. Most of the reported errors were around missing handling of async operations, easily resolved with a `.catch()`. There was also one instance of an await being used on a non-async method, and some whitespace cleanup.