### PR TITLE
Constrain last received callsign list to mini-mode bounds

### DIFF
--- a/src/renderer/src/components/mini.tsx
+++ b/src/renderer/src/components/mini.tsx
@@ -16,7 +16,7 @@ const Mini: React.FC = () => {
         setIsHovered(false);
       }}
     >
-      <div className="container">
+      <div className="container radio-list">
         {radios
           .filter((r) => r.rx)
           .map((radio) => {

--- a/src/renderer/src/style/app.scss
+++ b/src/renderer/src/style/app.scss
@@ -385,6 +385,12 @@ select:disabled {
   font-size: $mini-font-size;
 }
 
+.radio-list
+{
+  max-height: 80vh;
+  overflow-y: auto;
+}
+
 // When changing the max-width property make sure to update the miniModeWidthBreakpoint constant in
 // the toggleMiniMode method in index.ts as well.
 @media only screen and (max-width: $mini-mode-width-break-point) {


### PR DESCRIPTION
Fixes #138

* Limit bounds to 90vh, show scrollbar

Looks like this:

![image](https://github.com/user-attachments/assets/46d6f484-dab4-4744-bd4f-80bb337788c3)
