### PR TITLE
Add `kStationAdded` and `kFrequencyRemoved` websocket events

### DIFF
--- a/backend/include/sdk.hpp
+++ b/backend/include/sdk.hpp
@@ -79,6 +79,21 @@ public:
      */
     void publishStationState(const nlohmann::json& state);
 
+    /**
+     * @brief Publishes the kStationAdded message.
+     *
+     * @param callsign The callsign for the added station.
+     * @param frequencyHz The frequency for the added station.
+     */
+    void publishStationAdded(const std::string& callsign, const int& frequencyHz);
+
+    /**
+     * @brief Publishes the kFrequencyRemoved message.
+     *
+     * @param frequencyHz The removed frequency.
+     */
+    void publishFrequencyRemoved(const int& frequencyHz);
+
 private:
     using serverTraits = restinio::traits_t<restinio::asio_timer_manager_t, restinio::null_logger_t,
         restinio::router::express_router_t<>>;

--- a/backend/include/sdkWebsocketMessage.hpp
+++ b/backend/include/sdkWebsocketMessage.hpp
@@ -15,6 +15,8 @@ enum class WebsocketMessageType {
     kStationStateUpdate,
     kStationStates,
     kVoiceConnectedState,
+    kFrequencyRemoved,
+    kStationAdded
 };
 
 inline const std::map<WebsocketMessageType, std::string>& getWebsocketMessageTypeMap()
@@ -28,7 +30,8 @@ inline const std::map<WebsocketMessageType, std::string>& getWebsocketMessageTyp
         { WebsocketMessageType::kStationStates, "kStationStates" },
         { WebsocketMessageType::kStationStateUpdate, "kStationStateUpdate" },
         { WebsocketMessageType::kVoiceConnectedState, "kVoiceConnectedState" },
-
+        { WebsocketMessageType::kFrequencyRemoved, "kFrequencyRemoved" },
+        { WebsocketMessageType::kStationAdded, "kStationAdded" },
     };
     return kWebsocketMessageTypeMap;
 }

--- a/backend/src/main.cpp
+++ b/backend/src/main.cpp
@@ -180,6 +180,8 @@ void RemoveFrequency(const Napi::CallbackInfo& info)
 
     RadioHelper::SetRadioState(MainThreadShared::mApiServer, newState);
     mClient->RemoveFrequency(newState.frequency);
+
+    MainThreadShared::mApiServer->publishFrequencyRemoved(newState.frequency);
 }
 
 void Reset(const Napi::CallbackInfo& /*info*/) { mClient->reset(); }
@@ -450,8 +452,7 @@ static void HandleAfvEvents(afv_native::ClientEventType eventType, void* data, v
         }
 
         NapiHelpers::callElectron("StationDataReceived", callsign, std::to_string(frequency));
-        MainThreadShared::mApiServer->handleAFVEventForWebsocket(
-            sdk::types::Event::kStationStateUpdated, callsign, frequency);
+        MainThreadShared::mApiServer->publishStationAdded(callsign, frequency);
     }
 
     if (eventType == afv_native::ClientEventType::VccsReceived) {
@@ -473,8 +474,7 @@ static void HandleAfvEvents(afv_native::ClientEventType eventType, void* data, v
             }
 
             NapiHelpers::callElectron("StationDataReceived", callsign, std::to_string(frequency));
-            MainThreadShared::mApiServer->handleAFVEventForWebsocket(
-                sdk::types::Event::kStationStateUpdated, callsign, frequency);
+            MainThreadShared::mApiServer->publishStationAdded(callsign, frequency);
         }
     }
 

--- a/backend/src/sdk.cpp
+++ b/backend/src/sdk.cpp
@@ -344,6 +344,27 @@ void SDK::publishStationState(const nlohmann::json& state)
     this->broadcastOnWebsocket(state.dump());
 }
 
+void SDK::publishStationAdded(const std::string& callsign, const int& frequencyHz)
+{
+    nlohmann::json jsonMessage
+        = WebsocketMessage::buildMessage(WebsocketMessageType::kStationAdded);
+
+    jsonMessage["value"]["callsign"] = callsign;
+    jsonMessage["value"]["frequency"] = frequencyHz;
+
+    this->broadcastOnWebsocket(jsonMessage.dump());
+}
+
+void SDK::publishFrequencyRemoved(const int& frequencyHz)
+{
+    nlohmann::json jsonMessage
+        = WebsocketMessage::buildMessage(WebsocketMessageType::kFrequencyRemoved);
+
+    jsonMessage["value"]["frequency"] = frequencyHz;
+
+    this->broadcastOnWebsocket(jsonMessage.dump());
+}
+
 void SDK::handleIncomingWebSocketRequest(const std::string& payload)
 {
     try {


### PR DESCRIPTION
Fixes #140 

* Adds the two events
* Calls `kFrequencyRemoved` when a frequency is removed in TrackAudio
* Replaces `kStationStateUpdated` with `kStationAdded` when `StationDataReceived` or `VccsReceived` events happen