### PR TITLE
Add No_Hardware as HardwareType to disable radio audio effects

### DIFF
--- a/backend/src/main.cpp
+++ b/backend/src/main.cpp
@@ -264,7 +264,7 @@ void SetRadioEffects(const Napi::CallbackInfo& info)
     auto enableInputFilters = false;
     auto enableOutputEffects = false;
 
-    if (radioEffects == "off") {
+    if (radioEffects == "on") {
         enableInputFilters = true;
         enableOutputEffects = true;
     }

--- a/backend/src/main.cpp
+++ b/backend/src/main.cpp
@@ -273,17 +273,25 @@ void SetRadioEffects(const Napi::CallbackInfo& info)
 {
     auto radioEffects = info[0].As<Napi::String>().Utf8Value();
     radioEffects = convertToLowercase(radioEffects);
-    auto enableInputFilters = true;
-    auto enableOutputEffects = true;
+    auto enableInputFilters;
+    auto enableOutputEffects;
 
-    if (radioEffects == "off" || radioEffects == "input") {
-      enableOutputEffects = false;
-    }
-
-    if (radioEffects == "off" || radioEffects == "output") {
+    if (radioEffects == "on") {
+        enableInputFilters = true;
+        enableOutputEffects = true;
+    } else if (radioEffects == "input") {
+        enableInputFilters = true;
+        enableOutputEffects = false;
+    } else if (radioEffects == "output") {
         enableInputFilters = false;
+        enableOutputEffects = true;
+    } else if (radioEffects == "off") {
+        enableInputFilters = false;
+        enableOutputEffects = false;
+    } else {
+        TRACK_LOG_WARNING("Invalid radioEffects value: {}", radioEffects);
+        return;
     }
-
     mClient->SetEnableInputFilters(enableInputFilters);
     mClient->SetEnableOutputEffects(enableOutputEffects);
 }

--- a/backend/src/main.cpp
+++ b/backend/src/main.cpp
@@ -258,6 +258,29 @@ void SetCid(const Napi::CallbackInfo& info)
     UserSession::cid = cid;
 }
 
+void SetRadioEffects(const Napi::CallbackInfo& info)
+{
+    auto radioEffects = info[0].As<Napi::String>().Utf8Value();
+    auto enableInputFilters = false;
+    auto enableOutputEffects = false;
+
+    if (radioEffects == "off") {
+        enableInputFilters = true;
+        enableOutputEffects = true;
+    }
+
+    if (radioEffects == "input") {
+      enableInputFilters = true;
+    }
+
+    if (radioEffects == "output") {
+        enableOutputEffects = true;
+    }
+
+    mClient->SetEnableInputFilters(enableInputFilters);
+    mClient->SetEnableOutputEffects(enableOutputEffects);
+}
+
 void SetHardwareType(const Napi::CallbackInfo& info)
 {
     auto hardwareTypeIndex = info[0].As<Napi::Number>().Int32Value();
@@ -269,10 +292,6 @@ void SetHardwareType(const Napi::CallbackInfo& info)
 
     if (hardwareTypeIndex == 2) {
         hardware = afv_native::HardwareType::Garex_220;
-    }
-
-    if (hardwareTypeIndex == 3) {
-        hardware = afv_native::HardwareType::No_Hardware;
     }
 
     mClient->SetHardware(hardware);
@@ -767,6 +786,9 @@ Napi::Object Init(Napi::Env env, Napi::Object exports)
     exports.Set(Napi::String::New(env, "SetPtt"), Napi::Function::New(env, SetPtt));
 
     exports.Set(Napi::String::New(env, "SetRadioGain"), Napi::Function::New(env, SetRadioGain));
+
+    exports.Set(
+        Napi::String::New(env, "SetRadioEffects"), Napi::Function::New(env, SetRadioEffects));
 
     exports.Set(
         Napi::String::New(env, "SetHardwareType"), Napi::Function::New(env, SetHardwareType));

--- a/backend/src/main.cpp
+++ b/backend/src/main.cpp
@@ -7,6 +7,7 @@
 #include <absl/strings/ascii.h>
 #include <absl/strings/match.h>
 #include <atomic>
+#include <cctype>
 #include <chrono>
 #include <cstddef>
 #include <httplib.h>
@@ -258,10 +259,20 @@ void SetCid(const Napi::CallbackInfo& info)
     UserSession::cid = cid;
 }
 
+std::string convertToLowercase(const std::string& str)
+{
+  std::string result = "";
+
+  for (char ch : str) {
+    result += std::tolower(ch);
+  }
+  return result;
+}
+
 void SetRadioEffects(const Napi::CallbackInfo& info)
 {
     auto radioEffects = info[0].As<Napi::String>().Utf8Value();
-    std::transform(radioEffects.begin(), radioEffects.end(), radioEffects.begin(), std::tolower);
+    radioEffects = convertToLowercase(radioEffects);
     auto enableInputFilters = true;
     auto enableOutputEffects = true;
 

--- a/backend/src/main.cpp
+++ b/backend/src/main.cpp
@@ -261,20 +261,16 @@ void SetCid(const Napi::CallbackInfo& info)
 void SetRadioEffects(const Napi::CallbackInfo& info)
 {
     auto radioEffects = info[0].As<Napi::String>().Utf8Value();
-    auto enableInputFilters = false;
-    auto enableOutputEffects = false;
+    std::transform(radioEffects.begin(), radioEffects.end(), radioEffects.begin(), std::tolower);
+    auto enableInputFilters = true;
+    auto enableOutputEffects = true;
 
-    if (radioEffects == "on") {
-        enableInputFilters = true;
-        enableOutputEffects = true;
+    if (radioEffects == "off" || radioEffects == "input") {
+      enableOutputEffects = false;
     }
 
-    if (radioEffects == "input") {
-      enableInputFilters = true;
-    }
-
-    if (radioEffects == "output") {
-        enableOutputEffects = true;
+    if (radioEffects == "off" || radioEffects == "output") {
+        enableInputFilters = false;
     }
 
     mClient->SetEnableInputFilters(enableInputFilters);

--- a/backend/src/main.cpp
+++ b/backend/src/main.cpp
@@ -271,6 +271,10 @@ void SetHardwareType(const Napi::CallbackInfo& info)
         hardware = afv_native::HardwareType::Garex_220;
     }
 
+    if (hardwareTypeIndex == 3) {
+        hardware = afv_native::HardwareType::No_Hardware;
+    }
+
     mClient->SetHardware(hardware);
 }
 

--- a/backend/src/main.cpp
+++ b/backend/src/main.cpp
@@ -259,22 +259,12 @@ void SetCid(const Napi::CallbackInfo& info)
     UserSession::cid = cid;
 }
 
-std::string convertToLowercase(const std::string& str)
-{
-  std::string result = "";
-
-  for (char ch : str) {
-    result += std::tolower(ch);
-  }
-  return result;
-}
-
 void SetRadioEffects(const Napi::CallbackInfo& info)
 {
     auto radioEffects = info[0].As<Napi::String>().Utf8Value();
-    radioEffects = convertToLowercase(radioEffects);
-    auto enableInputFilters;
-    auto enableOutputEffects;
+    radioEffects = absl::AsciiStrToLower(radioEffects);
+    bool enableInputFilters;
+    bool enableOutputEffects;
 
     if (radioEffects == "on") {
         enableInputFilters = true;

--- a/backend/types/index.d.ts
+++ b/backend/types/index.d.ts
@@ -78,6 +78,8 @@ declare namespace TrackAudioAfv {
   export function SetRadioGain(gain: number): void;
   export function SetPtt(activate: boolean): void;
 
+  export function SetRadioEffects(type: string): void;
+
   export function SetHardwareType(type: number): void;
 
   export function StartMicTest(): void;

--- a/package-lock.json
+++ b/package-lock.json
@@ -8218,7 +8218,7 @@
     "node_modules/trackaudio-afv": {
       "version": "1.0.0",
       "resolved": "file:backend/trackaudio-afv-1.0.0.tgz",
-      "integrity": "sha512-uy2CO4u+6luDl7WGbPx6+TBHhPf+0GQ7ozs/+oY/XEuHP250Mv34wINKjBRT2pQoAFIABbGSXEZFDuDKbWWyUg==",
+      "integrity": "sha512-tjVkginiREmDG2jumOlvXa1P8xViKT1EnJtAeFJEuMlzw49DiplusOl2Nh7xvnjQr6ePJ3doiE9Pw0dKZz4MOg==",
       "license": "GPL-3.0-only",
       "dependencies": {
         "bindings": "^1.5.0",

--- a/src/main/config.ts
+++ b/src/main/config.ts
@@ -18,6 +18,7 @@ export const defaultConfiguration = {
   cid: '',
   password: '',
   callsign: '',
+  radioEffects: 'on',
   hardwareType: 0,
   radioGain: 0,
   alwaysOnTop: 'never' as AlwaysOnTopMode
@@ -35,7 +36,7 @@ export interface Configuration {
   password: string;
   callsign: string;
 
-  radioEffects: string;
+  radioEffects: "on" | "input" | "output" | "off";
   hardwareType: number;
   radioGain: number;
 

--- a/src/main/config.ts
+++ b/src/main/config.ts
@@ -36,6 +36,7 @@ export interface Configuration {
   password: string;
   callsign: string;
 
+  radioEffects: string;
   hardwareType: number;
   radioGain: number;
 

--- a/src/main/config.ts
+++ b/src/main/config.ts
@@ -1,6 +1,8 @@
 import { dialog } from 'electron';
 import Store from 'electron-store';
 
+export type RadioEffects = 'on' | 'input' | 'output' | 'off';
+
 export type AlwaysOnTopMode = 'never' | 'always' | 'inMiniMode';
 
 // Used to check for older settings that need upgrading. This should get
@@ -18,7 +20,7 @@ export const defaultConfiguration = {
   cid: '',
   password: '',
   callsign: '',
-  radioEffects: 'on',
+  radioEffects: 'on' as RadioEffects,
   hardwareType: 0,
   radioGain: 0,
   alwaysOnTop: 'never' as AlwaysOnTopMode
@@ -36,7 +38,7 @@ export interface Configuration {
   password: string;
   callsign: string;
 
-  radioEffects: "on" | "input" | "output" | "off";
+  radioEffects: RadioEffects;
   hardwareType: number;
   radioGain: number;
 

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -471,6 +471,11 @@ ipcMain.handle('set-radio-gain', (_, radioGain: number) => {
   TrackAudioAfv.SetRadioGain(radioGain);
 });
 
+ipcMain.handle('set-radio-effects', (_, radioEffects: string) => {
+  configManager.updateConfig({ radioEffects });
+  TrackAudioAfv.SetRadioEffects(radioEffects);
+});
+
 ipcMain.handle('set-hardware-type', (_, hardwareType: number) => {
   configManager.updateConfig({ hardwareType });
   TrackAudioAfv.SetHardwareType(hardwareType);

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -55,6 +55,7 @@ const setAudioSettings = () => {
     configManager.config.headsetOutputDeviceId,
     configManager.config.speakerOutputDeviceId
   );
+  TrackAudioAfv.SetRadioEffects(configManager.config.radioEffects);
   TrackAudioAfv.SetHardwareType(configManager.config.hardwareType);
 };
 

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -4,7 +4,7 @@ import Store from 'electron-store';
 import { join } from 'path';
 import { AfvEventTypes, TrackAudioAfv } from 'trackaudio-afv';
 import icon from '../../resources/AppIcon/icon.png?asset';
-import configManager, { AlwaysOnTopMode } from './config';
+import configManager, {AlwaysOnTopMode, RadioEffects} from './config';
 
 type WindowMode = 'mini' | 'maxi';
 
@@ -433,7 +433,7 @@ ipcMain.handle('set-radio-gain', (_, radioGain: number) => {
   TrackAudioAfv.SetRadioGain(radioGain);
 });
 
-ipcMain.handle('set-radio-effects', (_, radioEffects: string) => {
+ipcMain.handle('set-radio-effects', (_, radioEffects: RadioEffects) => {
   configManager.updateConfig({ radioEffects });
   TrackAudioAfv.SetRadioEffects(radioEffects);
 });

--- a/src/preload/bindings.ts
+++ b/src/preload/bindings.ts
@@ -1,5 +1,5 @@
 import { ipcRenderer, IpcRendererEvent } from 'electron';
-import { AlwaysOnTopMode } from '../main/config';
+import {AlwaysOnTopMode, RadioEffects} from '../main/config';
 
 export const api = {
   /* eslint-disable  @typescript-eslint/no-explicit-any */
@@ -67,7 +67,7 @@ export const api = {
 
   SetRadioGain: (gain: number) => ipcRenderer.invoke('set-radio-gain', gain),
 
-  SetRadioEffects: (type: string) => ipcRenderer.invoke('set-radio-effects', type),
+  SetRadioEffects: (type: RadioEffects) => ipcRenderer.invoke('set-radio-effects', type),
 
   SetHardwareType: (type: number) => ipcRenderer.invoke('set-hardware-type', type),
 

--- a/src/preload/bindings.ts
+++ b/src/preload/bindings.ts
@@ -67,6 +67,8 @@ export const api = {
 
   SetRadioGain: (gain: number) => ipcRenderer.invoke('set-radio-gain', gain),
 
+  SetRadioEffects: (type: string) => ipcRenderer.invoke('set-radio-effects', type),
+
   SetHardwareType: (type: number) => ipcRenderer.invoke('set-hardware-type', type),
 
   getVersion: () => ipcRenderer.invoke('get-version'),

--- a/src/renderer/src/components/settings-modal/settings-modal.tsx
+++ b/src/renderer/src/components/settings-modal/settings-modal.tsx
@@ -24,7 +24,7 @@ const SettingsModal: React.FC<SettingsModalProps> = ({ closeModal }) => {
   const [audioApis, setAudioApis] = useState(Array<AudioApi>);
   const [audioOutputDevices, setAudioOutputDevices] = useState(Array<AudioDevice>);
   const [audioInputDevices, setAudioInputDevices] = useState(Array<AudioDevice>);
-  const [radioEffects, setRadioEffects] = useState(0);
+  const [radioEffects, setRadioEffects] = useState("on");
   const [hardwareType, setHardwareType] = useState(0);
   const [config, setConfig] = useState({} as Configuration);
   const [alwaysOnTop, setAlwaysOnTop] = useState<AlwaysOnTopMode>('never');
@@ -197,7 +197,7 @@ const SettingsModal: React.FC<SettingsModalProps> = ({ closeModal }) => {
     setChangesSaved(SaveStatus.Saving);
     const radioEffects = e.target.value;
     void window.api.SetRadioEffects(radioEffects);
-    setHardwareType(radioEffects);
+    setRadioEffects(radioEffects);
     setConfig({ ...config, radioEffects: radioEffects });
     setChangesSaved(SaveStatus.Saved);
   };

--- a/src/renderer/src/components/settings-modal/settings-modal.tsx
+++ b/src/renderer/src/components/settings-modal/settings-modal.tsx
@@ -2,7 +2,7 @@ import clsx from 'clsx';
 import React, { useEffect, useState } from 'react';
 import { AudioApi, AudioDevice } from 'trackaudio-afv';
 import { useDebouncedCallback } from 'use-debounce';
-import { AlwaysOnTopMode, Configuration } from '../../../../../src/main/config';
+import {AlwaysOnTopMode, Configuration, RadioEffects} from '../../../../../src/main/config';
 import useRadioState from '../../store/radioStore';
 import useUtilStore from '../../store/utilStore';
 import AudioApis from './audio-apis';
@@ -24,7 +24,7 @@ const SettingsModal: React.FC<SettingsModalProps> = ({ closeModal }) => {
   const [audioApis, setAudioApis] = useState(Array<AudioApi>);
   const [audioOutputDevices, setAudioOutputDevices] = useState(Array<AudioDevice>);
   const [audioInputDevices, setAudioInputDevices] = useState(Array<AudioDevice>);
-  const [radioEffects, setRadioEffects] = useState("on");
+  const [radioEffects, setRadioEffects] = useState<RadioEffects>("on");
   const [hardwareType, setHardwareType] = useState(0);
   const [config, setConfig] = useState({} as Configuration);
   const [alwaysOnTop, setAlwaysOnTop] = useState<AlwaysOnTopMode>('never');
@@ -195,10 +195,10 @@ const SettingsModal: React.FC<SettingsModalProps> = ({ closeModal }) => {
 
   const handleRadioEffectsChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
     setChangesSaved(SaveStatus.Saving);
-    const radioEffects = e.target.value;
+    const radioEffects = e.target.value as RadioEffects;
     void window.api.SetRadioEffects(radioEffects);
     setRadioEffects(radioEffects);
-    setConfig({ ...config, radioEffects: radioEffects });
+    setConfig({ ...config, radioEffects: radioEffects});
     setChangesSaved(SaveStatus.Saved);
   };
 

--- a/src/renderer/src/components/settings-modal/settings-modal.tsx
+++ b/src/renderer/src/components/settings-modal/settings-modal.tsx
@@ -24,6 +24,7 @@ const SettingsModal: React.FC<SettingsModalProps> = ({ closeModal }) => {
   const [audioApis, setAudioApis] = useState(Array<AudioApi>);
   const [audioOutputDevices, setAudioOutputDevices] = useState(Array<AudioDevice>);
   const [audioInputDevices, setAudioInputDevices] = useState(Array<AudioDevice>);
+  const [radioEffects, setRadioEffects] = useState(0);
   const [hardwareType, setHardwareType] = useState(0);
   const [config, setConfig] = useState({} as Configuration);
   const [alwaysOnTop, setAlwaysOnTop] = useState<AlwaysOnTopMode>('never');
@@ -63,6 +64,7 @@ const SettingsModal: React.FC<SettingsModalProps> = ({ closeModal }) => {
         setConfig(config);
         setCid(config.cid);
         setPassword(config.password);
+        setRadioEffects(config.radioEffects);
         setHardwareType(config.hardwareType);
         setAlwaysOnTop(config.alwaysOnTop as AlwaysOnTopMode); // Type assertion since the config will never be a boolean at this point
       })
@@ -191,6 +193,15 @@ const SettingsModal: React.FC<SettingsModalProps> = ({ closeModal }) => {
     void window.api.StartMicTest();
   };
 
+  const handleRadioEffectsChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
+    setChangesSaved(SaveStatus.Saving);
+    const radioEffects = e.target.value;
+    void window.api.SetRadioEffects(radioEffects);
+    setHardwareType(radioEffects);
+    setConfig({ ...config, radioEffects: radioEffects });
+    setChangesSaved(SaveStatus.Saved);
+  };
+
   const handleHardwareTypeChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
     setChangesSaved(SaveStatus.Saving);
     const hardwareType = parseInt(e.target.value);
@@ -250,13 +261,18 @@ const SettingsModal: React.FC<SettingsModalProps> = ({ closeModal }) => {
                   ></input>
 
                   <h5 className="mt-4">Other</h5>
-                  {/* <label className="mt-1">Radio Effects</label>
-                  <select id="" className="form-control mt-1" disabled>
+
+                  <label className="mt-1">Radio Effects</label>
+                  <select id=""
+                    className="form-control mt-1"
+                    value={radioEffects}
+                    onChange={handleRadioEffectsChange}>
                     <option value="on">On</option>
-                    <option value="saab">Input only</option>
-                    <option value="mercedes">Output only</option>
-                    <option value="audi">Off</option>
-                  </select> */}
+                    <option value="input">Input only</option>
+                    <option value="output">Output only</option>
+                    <option value="off">Off</option>
+                  </select>
+
                   <label className="mt-2">Radio Hardware</label>
                   <select
                     id=""
@@ -267,7 +283,6 @@ const SettingsModal: React.FC<SettingsModalProps> = ({ closeModal }) => {
                     <option value="0">Schmid ED-137B</option>
                     <option value="1">Rockwell Collins 2100</option>
                     <option value="2">Garex 220</option>
-                    <option value="3">No Hardware (Real Radio Affects disabled)</option>
                   </select>
 
                   <label className="mt-2">Keep window on top</label>

--- a/src/renderer/src/components/settings-modal/settings-modal.tsx
+++ b/src/renderer/src/components/settings-modal/settings-modal.tsx
@@ -250,6 +250,7 @@ const SettingsModal: React.FC<SettingsModalProps> = ({ closeModal }) => {
                     <option value="0">Schmid ED-137B</option>
                     <option value="1">Rockwell Collins 2100</option>
                     <option value="2">Garex 220</option>
+                    <option value="3">No Hardware (Real Radio Affects disabled)</option>
                   </select>
 
                   <label className="mt-2">Keep window on top</label>

--- a/src/renderer/src/components/settings-modal/settings-modal.tsx
+++ b/src/renderer/src/components/settings-modal/settings-modal.tsx
@@ -252,8 +252,6 @@ const SettingsModal: React.FC<SettingsModalProps> = ({ closeModal }) => {
                     onChange={(e) => debouncedPassword(e.target.value)}
                   ></input>
 
-                  <h5 className="mt-4">Other</h5>
-
                   <label className="mt-1">Radio Effects</label>
                   <select id=""
                     className="form-control mt-1"


### PR DESCRIPTION
This pull requests add the hardwareTypeIndex to the "No_Hardware" type of the HardwareType enum and the "No Hardware (Real Radio Affects disabled)" option with value 3 to the hardware select of the settings-modal.tsx, to make it possible to disable radio affects in TrackAudio.

This pull request shall implement the issue: https://github.com/pierr3/TrackAudio/issues/156
This pull request is dependent on the afv-native pull request: https://github.com/pierr3/afv-native/pull/13