### PR TITLE
Attach CI artifacts to the run result

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,12 +80,8 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: npm run build:${{ matrix.platform }}
 
-  upload-artifacts:
-    runs-on: ubuntu-latest
-    needs: build
-    steps:
-      - name: Upload artifacts for all platforms
+      - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
-          name: TrackAudio
-          path: dist/
+          name: TrackAudio-${{ matrix.platform }}
+          path: dist/trackaudio-*.*

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,3 +79,13 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: npm run build:${{ matrix.platform }}
+
+  upload-artifacts:
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Upload artifacts for all platforms
+        uses: actions/upload-artifact@v4
+        with:
+          name: TrackAudio
+          path: dist/


### PR DESCRIPTION
Fixes #168 

Adds the artifacts to the end of the action run. [See the run for this PR as an example](https://github.com/pierr3/TrackAudio/actions/runs/10761575125):

![image](https://github.com/user-attachments/assets/b25654aa-c971-4a48-8285-1d07d1ec0f52)

Note that the mac binaries are not signed, which is expected.