### PR TITLE
Sort GUARD and UNICOM to the bottom of the mini-mode list

### DIFF
--- a/src/renderer/src/helpers/RadioHelper.ts
+++ b/src/renderer/src/helpers/RadioHelper.ts
@@ -1,5 +1,7 @@
 import { RadioType } from '../store/radioStore';
 
+const endStations = ['GUARD', 'UNICOM'];
+
 /**
  * Compares two radios to determine sort order. The currently connected station
  * will always sort to the front of the list. The remaining stations will sort
@@ -18,6 +20,13 @@ export const radioCompare = (
   // The connected station always get sorted to the front of the list.
   if (a.callsign === connectedStationCallsign) return -1;
   if (b.callsign === connectedStationCallsign) return 1;
+
+  // Always push "GUARD" and "UNICOM" to the end of the list
+  const aIsEndStation = endStations.includes(a.station);
+  const bIsEndStation = endStations.includes(b.station);
+
+  if (aIsEndStation && !bIsEndStation) return 1;
+  if (!aIsEndStation && bIsEndStation) return -1;
 
   // The station name takes sort priority
   const stationComparison = a.station.localeCompare(b.station);


### PR DESCRIPTION
Fixes #198

Forces GUARD and UNICOM to be at the bottom of the mini-mode list so they don't break up the actual frequencies you may be staffing/listening to.

While it's not *explicitly* making GUARD show before UNICOM, in my testing that's how they've always wound up sorting with this code so I'm calling it good enough...

![image](https://github.com/user-attachments/assets/e9b06e0e-df0a-4294-bb64-abea3023b39f)
