### PR TITLE
Improve version check

### DIFF
--- a/backend/include/Shared.hpp
+++ b/backend/include/Shared.hpp
@@ -15,6 +15,8 @@
 #define SLURPER_DATA_ENDPOINT "/users/info/"
 #define VERSION_CHECK_BASE_URL "https://raw.githubusercontent.com"
 #define VERSION_CHECK_ENDPOINT "/pierr3/TrackAudio/main/MANDATORY_VERSION"
+#define VERSION_CHECK_BASE_URL_CDN "https://cdn.jsdelivr.net"
+#define VERSION_CHECK_ENDPOINT_CDN "/gh/pierr3/TrackAudio@main/MANDATORY_VERSION"
 #define OBS_FREQUENCY 199998000 // 199.998
 #define UNICOM_FREQUENCY 122800000 // 122.800
 #define GUARD_FREQUENCY 121500000 // 121.500

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -348,10 +348,9 @@ app
       dialog.showMessageBoxSync({
         type: 'error',
         message:
-          'An error occured during the version check, either your internet connection is down or the server (raw.githubusercontent.com or cdn.jsdelivr.net) is unreachable.',
+          'An error occured during the version check, either your internet connection is down or both servers (raw.githubusercontent.com and cdn.jsdelivr.net) are unreachable.',
         buttons: ['OK']
       });
-      app.quit();
     }
 
     if (bootstrapOutput.needUpdate) {

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -179,7 +179,7 @@ const createWindow = (): void => {
   // Set the logger file path
   log.transports.file.format = '{y}-{m}-{d} {h}:{i}:{s}:{ms} {level} [ELECTRON] {text}';
   log.transports.file.resolvePathFn = (): string => {
-    return TrackAudioAfv.GetLoggerFilePath();
+    return TrackAudioAfv.GetLoggerFilePath() as string;
   };
 
   const options: Electron.BrowserWindowConstructorOptions = {

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -179,7 +179,7 @@ const createWindow = (): void => {
   // Set the logger file path
   log.transports.file.format = '{y}-{m}-{d} {h}:{i}:{s}:{ms} {level} [ELECTRON] {text}';
   log.transports.file.resolvePathFn = (): string => {
-    return TrackAudioAfv.GetLoggerFilePath() as string;
+    return TrackAudioAfv.GetLoggerFilePath();
   };
 
   const options: Electron.BrowserWindowConstructorOptions = {
@@ -348,7 +348,7 @@ app
       dialog.showMessageBoxSync({
         type: 'error',
         message:
-          'An error occured during the version check, either your internet connection is down or the server (raw.githubusercontent.com) is unreachable.',
+          'An error occured during the version check, either your internet connection is down or the server (raw.githubusercontent.com or cdn.jsdelivr.net) is unreachable.',
         buttons: ['OK']
       });
       app.quit();


### PR DESCRIPTION
+ Add a CDN source (https://cdn.jsdelivr.net/gh/pierr3/TrackAudio@main/MANDATORY_VERSION) for version check.
+ Set version check timeout to 5 seconds to reduce waiting time.
+ Allow app to run when version check fails. Mandatory update will only be considered when version check response is valid.