### PR TITLE
Add `frequencyAlias` to `kStationAdded` messages

### DIFF
--- a/backend/include/sdk.hpp
+++ b/backend/include/sdk.hpp
@@ -119,6 +119,7 @@ public:
 
     void publishStationState(const nlohmann::json& state, bool broadcastToElectron = true);
     void publishMainVolumeChange(const float& volume, bool broadcastToElectron = true);
-    void publishStationAdded(const std::string& callsign, const int& frequencyHz);
+    void publishStationAdded(
+        const std::string& callsign, const int& frequencyHz, const int& frequencyAlias);
     void publishFrequencyRemoved(const int& frequencyHz);
 };

--- a/backend/include/sdk.hpp
+++ b/backend/include/sdk.hpp
@@ -119,7 +119,7 @@ public:
 
     void publishStationState(const nlohmann::json& state, bool broadcastToElectron = true);
     void publishMainVolumeChange(const float& volume, bool broadcastToElectron = true);
-    void publishStationAdded(
-        const std::string& callsign, const int& frequencyHz, const int& frequencyAlias);
+    void publishStationAdded(const std::string& callsign, const int& frequencyHz,
+        const std::optional<int>& frequencyAlias = std::nullopt);
     void publishFrequencyRemoved(const int& frequencyHz);
 };

--- a/backend/src/main.cpp
+++ b/backend/src/main.cpp
@@ -596,8 +596,8 @@ void HandleAfvEvents()
                 stationJson["frequencyAlias"] = station.frequencyAlias;
 
                 NapiHelpers::callElectron("StationDataReceived", callsign, stationJson.dump());
-                MainThreadShared::mApiServer->publishStationAdded(
-                    callsign, static_cast<int>(frequency), static_cast<int>(frequencyAlias));
+                MainThreadShared::mApiServer->publishStationAdded(callsign,
+                    static_cast<int>(frequency), static_cast<int>(station.frequencyAlias));
             }
         });
 

--- a/backend/src/main.cpp
+++ b/backend/src/main.cpp
@@ -573,7 +573,7 @@ void HandleAfvEvents()
 
             NapiHelpers::callElectron("StationDataReceived", callsign, stationJson.dump());
             MainThreadShared::mApiServer->publishStationAdded(
-                callsign, static_cast<int>(frequency));
+                callsign, static_cast<int>(frequency), static_cast<int>(station.frequencyAlias));
         });
 
     event.AddHandler<afv_native::VccsReceivedEvent>(
@@ -597,7 +597,7 @@ void HandleAfvEvents()
 
                 NapiHelpers::callElectron("StationDataReceived", callsign, stationJson.dump());
                 MainThreadShared::mApiServer->publishStationAdded(
-                    callsign, static_cast<int>(frequency));
+                    callsign, static_cast<int>(frequency), static_cast<int>(frequencyAlias));
             }
         });
 

--- a/backend/src/sdk.cpp
+++ b/backend/src/sdk.cpp
@@ -258,13 +258,16 @@ void SDK::publishMainVolumeChange(const float& volume, bool broadcastToElectron)
 }
 
 void SDK::publishStationAdded(
-    const std::string& callsign, const int& frequencyHz, const int& frequencyAlias)
+    const std::string& callsign, const int& frequencyHz, const std::optional<int>& frequencyAlias)
 {
     nlohmann::json jsonMessage
         = WebsocketMessage::buildMessage(WebsocketMessageType::kStationAdded);
     jsonMessage["value"]["callsign"] = callsign;
     jsonMessage["value"]["frequency"] = frequencyHz;
-    jsonMessage["value"]["frequencyAlias"] = frequencyAlias;
+    if (frequencyAlias.has_value()) {
+        jsonMessage["value"]["frequencyAlias"] = frequencyAlias.value();
+    }
+
     broadcastMessage(jsonMessage.dump(), MessageScope::AllClients);
 }
 

--- a/backend/src/sdk.cpp
+++ b/backend/src/sdk.cpp
@@ -264,7 +264,7 @@ void SDK::publishStationAdded(
         = WebsocketMessage::buildMessage(WebsocketMessageType::kStationAdded);
     jsonMessage["value"]["callsign"] = callsign;
     jsonMessage["value"]["frequency"] = frequencyHz;
-    if (frequencyAlias.has_value()) {
+    if (frequencyAlias.has_value() && frequencyAlias.value() != 0) {
         jsonMessage["value"]["frequencyAlias"] = frequencyAlias.value();
     }
 

--- a/backend/src/sdk.cpp
+++ b/backend/src/sdk.cpp
@@ -257,12 +257,14 @@ void SDK::publishMainVolumeChange(const float& volume, bool broadcastToElectron)
         "main-volume-change");
 }
 
-void SDK::publishStationAdded(const std::string& callsign, const int& frequencyHz)
+void SDK::publishStationAdded(
+    const std::string& callsign, const int& frequencyHz, const int& frequencyAlias)
 {
     nlohmann::json jsonMessage
         = WebsocketMessage::buildMessage(WebsocketMessageType::kStationAdded);
     jsonMessage["value"]["callsign"] = callsign;
     jsonMessage["value"]["frequency"] = frequencyHz;
+    jsonMessage["value"]["frequencyAlias"] = frequencyAlias;
     broadcastMessage(jsonMessage.dump(), MessageScope::AllClients);
 }
 


### PR DESCRIPTION
Fixes #261 

Example message now for a station with an alias, new property included:

```json
{
    "type": "kStationAdded",
    "value": {
        "callsign": "NAT_FSS",
        "frequency": 5649000,
        "frequencyAlias": 131900000
    }
}
```

Example message now for a station without an alias, unchanged from current behaviour:

```json
{
    "type": "kStationAdded",
    "value": {
        "callsign": "CZQO_DEL",
        "frequency": 128700000
    }
}
```