### PR TITLE
logic change: Don't do anything if the slurper is not available.

### DIFF
--- a/backend/src/RemoteData.cpp
+++ b/backend/src/RemoteData.cpp
@@ -179,6 +179,11 @@ bool RemoteData::parseSlurper(const std::string& sluper_data)
 
 void RemoteData::updateSessionStatus(const std::string& previousCallsign, bool isConnected)
 {
+    if (!RemoteDataStatus::isSlurperAvailable) {
+        // Don't do anything if the slurper is not available.
+        return;
+    }
+
     if (UserSession::isConnectedToTheNetwork && UserSession::callsign != previousCallsign
         && !previousCallsign.empty() && isConnected && mClient->IsVoiceConnected()) {
         PLOG_INFO << "Callsign changed during an active session, disconnecting ("
@@ -239,9 +244,11 @@ void RemoteData::notifyUserOfSlurperUnavalability()
         userHasBeenNotifiedOfSlurperUnavailability = true;
     }
 
-    NapiHelpers::sendErrorToElectron("Error while parsing slurper data, check the log file. "
-                                     "This means your internet may be down or the VATSIM servers "
-                                     "may experience an outage. You will not be able to connect "
-                                     "until this is resolved. TrackAudio will keep retrying in the "
-                                     "background.");
+    NapiHelpers::sendErrorToElectron(
+        "Error while parsing slurper data, check the log file. "
+        "This means your internet may be down or the VATSIM servers "
+        "may experience an outage. Auto-disconnect will not be triggered, "
+        "you may need to disconnect afv manually when disconnect from the network, "
+        "until the service back online. TrackAudio will keep retrying "
+        "in the background.");
 };


### PR DESCRIPTION
- What's change:
  - Add a new judgment let do nothing but retry when slurper out of service.
- Why?
  - Availability between slurper service and afv service are not sync. The situation, the slurper is down but everything else alive, is exist.
  - Slurper service and most of other VATSIM services are running on different servers, the connection availability between users and servers will be different too. 
  
    > For example, someone can connect to the network normally, but fail to connect to slurper. It will cause the trackaudio "kick" that man out of the afv service. It may cause the channel lose its controller unexpectedly, especially in the division with a leak World-Wire-Internet, such as VATPRC.

  - I think we should give the right of disconnecting back to the controllers when the slurper not available. Noticing the controllers they should disconnect by themselves during the slurper not available might be better than force to.