### PR TITLE
Fix RX going dead after ~60 minutes

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -13,7 +13,7 @@
                 "node-addon-api": "^8.0.0"
             },
             "engines": {
-                "node": ">=22.0.0 <=23.0.0"
+                "node": ">=24.0.0 <25.0.0"
             }
         },
         "node_modules/bindings": {

--- a/backend/src/Shared.cpp
+++ b/backend/src/Shared.cpp
@@ -2,7 +2,7 @@
 #include "Helpers.hpp"
 #include <semver.hpp>
 
-const semver::version VERSION = semver::version { 1, 4, 0, semver::prerelease::beta, 7 };
+const semver::version VERSION = semver::version { 1, 4, 0, semver::prerelease::beta, 8 };
 const std::string CLIENT_NAME = std::string("TrackAudio-") + VERSION.to_string();
 std::unique_ptr<afv_native::api::atcClient> mClient = nullptr;
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "trackaudio",
   "productName": "TrackAudio",
-  "version": "1.4.0-beta.7",
+  "version": "1.4.0-beta.8",
   "main": "./out/main/index.js",
   "author": "github.com/pierr3",
   "description": "TrackAudio - Audio for VATSIM Client",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2939,9 +2939,9 @@ packages:
     engines: {node: '>=14.14'}
 
   trackaudio-afv@file:backend/trackaudio-afv-1.0.0.tgz:
-    resolution: {integrity: sha512-Nn/4QvgQEcBzPQ+sld+4dw9KvfjrbDJ2M+nf0S3pikqEgE0CZeqGKbssTYqvjbXV86xLwNQcA0GnFwbLaBqvRQ==, tarball: file:backend/trackaudio-afv-1.0.0.tgz}
+    resolution: {integrity: sha512-YhJvymzJgftlli91IItk5KfSkJVMpyyXgeMRNOm6SAKNHq5BqPkl0s+zT1ponBW1vlm2Xc4FOv35Qq+ukknQ4w==, tarball: file:backend/trackaudio-afv-1.0.0.tgz}
     version: 1.0.0
-    engines: {node: '>=22.0.0 <=23.0.0'}
+    engines: {node: '>=24.0.0 <25.0.0'}
 
   truncate-utf8-bytes@1.0.2:
     resolution: {integrity: sha512-95Pu1QXQvruGEhv62XCMO3Mm90GscOCClvrIUwCM0PYOXK3kaF3l3sIHxx71ThJfcbM2O5Au6SO3AWCSEfW4mQ==}


### PR DESCRIPTION
This can also be done by yourself, just adding it here for completeliness purposes. Check afv-native for most changes

## What

Reported against 1.4.0-beta.7: after roughly an hour of a session, TX
kept working but RX went completely silent, with nothing recoverable
short of an in-app reconnect.

Traced from a full session log: the hourly JWT refresh POST hung with no
callback ever firing, which left the AFV API session stuck in
Reconnecting permanently. The old token expired shortly after, transceiver
updates started coming back 401, the server dropped the client's
transceiver registration, and RX died while TX kept working over the
already-established voice channel.

## Context

Part of the conditions for this were introduced by my previous PR (the
libcurl.dll crash fix). That PR corrected doAsync() to actually call
shareState() on the request - previously a no-op bug - which had the side
effect of making the CURL share handle live across threads for the first
time. That share handle was never given the lock callbacks libcurl
requires for cross-thread use, which is the most likely source of the
stalled request behind this bug. So this is best read as finishing what
that PR started, not a fully separate issue.

## Changes

Bumps the afv-native submodule to pick up:
- Timeouts on every HTTP request, so a stalled transfer can't hang forever
- The missing share-handle lock callbacks
- A token refresh that retries with backoff instead of silently hanging
  or tearing down a live session on a single failed attempt

Also bumps the app version to 1.4.0-beta.8 and refreshes
backend/package-lock.json's stale engines field.

## Testing

Typecheck, lint and full native build all pass. Packaged and installed
locally

Again: this is a claude written description

@pierr3 