### PR TITLE
feat: Add RPM packaging support

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -72,7 +72,7 @@ jobs:
         if: matrix.os == 'ubuntu-latest' && matrix.arch == 'x64'
         run: |
           sudo apt-get update
-          sudo apt-get install -y libx11-dev libxrandr-dev libxcursor-dev libxi-dev libudev-dev libgl1-mesa-dev pkg-config libxtst-dev libxinerama-dev libx11-xcb-dev libxkbcommon-dev libxkbcommon-x11-dev libxkbfile-dev libxt-dev autoconf autoconf-archive automake libtool pkg-config libltdl-dev
+          sudo apt-get install -y rpm libx11-dev libxrandr-dev libxcursor-dev libxi-dev libudev-dev libgl1-mesa-dev pkg-config libxtst-dev libxinerama-dev libx11-xcb-dev libxkbcommon-dev libxkbcommon-x11-dev libxkbfile-dev libxt-dev autoconf autoconf-archive automake libtool pkg-config libltdl-dev
 
       - name: Replace repositories with amd64 and arm64 repositories
         if: matrix.os == 'ubuntu-latest' && matrix.arch == 'arm64'
@@ -96,7 +96,7 @@ jobs:
           sudo apt-get remove libgpg-error-dev
           sudo dpkg --add-architecture arm64
           sudo apt-get update
-          sudo apt-get install -y desktop-file-utils ninja-build gcc-aarch64-linux-gnu:amd64 g++-aarch64-linux-gnu:amd64 python3-jinja2:amd64 libgcrypt20:arm64 libgcrypt20-dev:arm64 libgpg-error-dev:arm64 libx11-dev:arm64 libxrandr-dev:arm64 libxcursor-dev:arm64 libxi-dev:arm64 libudev-dev:arm64 libgl1-mesa-dev:arm64
+          sudo apt-get install -y rpm desktop-file-utils ninja-build gcc-aarch64-linux-gnu:amd64 g++-aarch64-linux-gnu:amd64 python3-jinja2:amd64 libgcrypt20:arm64 libgcrypt20-dev:arm64 libgpg-error-dev:arm64 libx11-dev:arm64 libxrandr-dev:arm64 libxcursor-dev:arm64 libxi-dev:arm64 libudev-dev:arm64 libgl1-mesa-dev:arm64
 
       - name: Install dependencies and building backend (x64)
         if: matrix.arch == 'x64'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -227,3 +227,4 @@ jobs:
             dist/*.AppImage
             dist/*.zsync
             dist/*.snap
+            dist/*.rpm

--- a/README.md
+++ b/README.md
@@ -270,6 +270,17 @@ If it does not open, you might want to make sure it has permission to run as an 
 
 Note: this will install libafv_native.so in /usr/lib, a required library for TrackAudio to run.
 
+#### Fedora / RHEL / openSUSE (RPM-based)
+
+Download the latest `.rpm` release from the [release page](https://github.com/pierr3/TrackAudio/releases) and install it:
+
+```bash
+sudo dnf install ./trackaudio-*.rpm    # Fedora/RHEL
+sudo zypper install ./trackaudio-*.rpm # openSUSE
+```
+
+Note: this will install `libafv_native.so` in `/usr/lib64`, a required library for TrackAudio to run.
+
 ### macOS
 
 Download the latest release on the [release page](https://github.com/pierr3/TrackAudio/releases) and install the .app into your applications folder.
@@ -300,7 +311,18 @@ TrackAudio depends on afv-native and SFML (for input handling).
 
 `cmake` is required to build the project. Dependencies will be downloaded through vcpkg at build time. See vcpkg.json for further details.
 
-On Linux, the following packages are required: `build-essentials libx11-dev libxrandr-dev libxcursor-dev libxi-dev libudev-dev libgl1-mesa-dev pkg-config`, you may also need further packages to enable the different audio backends, such as Alsa, JACK or PulseAudio.
+On Linux, the following packages are required:
+
+- **Debian/Ubuntu**: `build-essential libx11-dev libxrandr-dev libxcursor-dev libxi-dev libudev-dev libgl1-mesa-dev pkg-config`
+- **Fedora/RHEL**: `gcc gcc-c++ cmake ninja-build pkgconf-pkg-config libX11-devel libXrandr-devel libXcursor-devel libXi-devel systemd-devel mesa-libGL-devel alsa-lib-devel`
+
+You may also need further packages to enable the different audio backends, such as Alsa, JACK or PulseAudio.
+
+> **Note (Fedora/RHEL build machines):** Building `deb`/`rpm` packages uses `fpm`, which bundles a Ruby binary linked against `libcrypt.so.1`. Fedora/RHEL ship `libxcrypt` instead, so you'll need to install the compatibility package first:
+> ```bash
+> sudo dnf install libxcrypt-compat
+> ```
+> Without this, packaging fails with `ruby: error while loading shared libraries: libcrypt.so.1: cannot open shared object file`.
 
 On macOS, XCode Command Line tools, CMake and Homebrew are required and the following homebrew package is required: `pkg-config`
 

--- a/electron-builder-config.js
+++ b/electron-builder-config.js
@@ -59,7 +59,7 @@ module.exports = {
     artifactName: '${name}-${version}-${arch}.${ext}'
   },
   linux: {
-    target: ['AppImage', 'snap', 'deb'],
+    target: ['AppImage', 'snap', 'deb', 'rpm'],
     maintainer: 'pierr3',
     category: 'Game',
     extraFiles: [


### PR DESCRIPTION
## Summary

Adds `rpm` as a Linux packaging target alongside the existing `deb`, `AppImage`, and `snap` builds, so TrackAudio can be installed natively on Fedora, RHEL, openSUSE, and other RPM-based distributions.

## Changes

- Added `rpm` to `linux.target` in `electron-builder-config.js`
- Updated `release.yml` to include `dist/*.rpm` in the GitHub release upload step, so built RPMs are actually attached to releases (otherwise they'd build but not get published)
- Updated `README.md`:
  - Added an RPM-based install section under **Installation -> Linux**
  - Added a note about the `libxcrypt-compat` dependency needed to build `deb`/`rpm` packages on Fedora/RHEL systems (via `fpm`'s bundled Ruby binary)

## Testing

Built and installed locally on Fedora 44:

```bash
pnpm run build:linux
sudo dnf install ./dist/trackaudio-*.rpm
```

Confirmed the app launches and audio I/O works as expected after connected to the network post-install.

## Notes for reviewers

- `ubuntu-latest` CI runners are Debian-based, so the `libxcrypt-compat` fix is **not** needed in CI — this is purely a note for anyone building locally on an RPM-based distro.