### PR TITLE
Add optional AFV editor station ordering

### DIFF
--- a/backend/src/main.cpp
+++ b/backend/src/main.cpp
@@ -703,6 +703,7 @@ void HandleAfvEvents()
             stationJson["name"] = station.name;
             stationJson["frequency"] = station.frequency;
             stationJson["frequencyAlias"] = station.frequencyAlias;
+            stationJson["afvOrder"] = 0;
 
             NapiHelpers::callElectron("StationDataReceived", callsign, stationJson.dump());
             if (MainThreadShared::mApiServer)
@@ -730,6 +731,11 @@ void HandleAfvEvents()
                 stationJson["name"] = station.name;
                 stationJson["frequency"] = station.frequency;
                 stationJson["frequencyAlias"] = station.frequencyAlias;
+                if (callsign == event.stationName) {
+                    stationJson["afvOrder"] = 0;
+                } else if (station.vccsOrder.has_value()) {
+                    stationJson["afvOrder"] = station.vccsOrder.value() + 1;
+                }
 
                 NapiHelpers::callElectron("StationDataReceived", callsign, stationJson.dump());
                 if (MainThreadShared::mApiServer)

--- a/src/main/config.ts
+++ b/src/main/config.ts
@@ -25,6 +25,7 @@ export const defaultConfiguration = {
   showExpandedRx: false,
   transparentMiniMode: false,
   radioToMaxVolumeOnTx: false,
+  sortStationsByAfvOrder: false,
   pttReleaseSoundEnabled: false,
   loopbackEnabled: false,
   loopbackTarget: 0,

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -506,6 +506,10 @@ ipcMain.on('set-radio-to-max-volume-on-tx', (_, radioToMaxVolumeOnTx: boolean) =
   configManager.updateConfig({ radioToMaxVolumeOnTx });
 });
 
+ipcMain.on('set-sort-stations-by-afv-order', (_, sortStationsByAfvOrder: boolean) => {
+  configManager.updateConfig({ sortStationsByAfvOrder });
+});
+
 ipcMain.on('set-ptt-release-sound-enabled', (_, pttReleaseSoundEnabled: boolean) => {
   configManager.updateConfig({ pttReleaseSoundEnabled });
   TrackAudioAfv.SetPttReleaseSoundEnabled(pttReleaseSoundEnabled);

--- a/src/preload/bindings.ts
+++ b/src/preload/bindings.ts
@@ -41,6 +41,9 @@ export const api = {
   setRadioToMaxVolumeOnTX: (state: boolean) => {
     ipcRenderer.send('set-radio-to-max-volume-on-tx', state);
   },
+  setSortStationsByAfvOrder: (state: boolean) => {
+    ipcRenderer.send('set-sort-stations-by-afv-order', state);
+  },
   setPttReleaseSoundEnabled: (enabled: boolean) => {
     ipcRenderer.send('set-ptt-release-sound-enabled', enabled);
   },

--- a/src/renderer/src/components/settings-modal/settings-modal.tsx
+++ b/src/renderer/src/components/settings-modal/settings-modal.tsx
@@ -5,6 +5,7 @@ import { useDebouncedCallback } from 'use-debounce';
 
 import { AlwaysOnTopMode, Configuration, RadioEffects } from '../../../../shared/config.type';
 import useRadioState from '../../store/radioStore';
+import useSessionStore from '../../store/sessionStore';
 import useUtilStore from '../../store/utilStore';
 import AudioApis from './audio-apis';
 import AudioInput from './audio-input';
@@ -57,11 +58,13 @@ const SettingsModal: React.FC<SettingsModalProps> = ({ closeModal }) => {
     updatePtt2KeySet,
     showExpandedRxInfo,
     radioToMaxVolumeOnTX,
+    sortStationsByAfvOrder,
     updateChannel,
     setShowExpandedRxInfo,
     setTransparentMiniMode,
     setPendingRestart,
     setRadioToMaxVolumeOnTX,
+    setSortStationsByAfvOrder,
     setUpdateChannel
   ] = useUtilStore((state) => [
     state.vu,
@@ -75,11 +78,13 @@ const SettingsModal: React.FC<SettingsModalProps> = ({ closeModal }) => {
     state.updatePtt2KeySet,
     state.showExpandedRxInfo,
     state.radioToMaxVolumeOnTX,
+    state.sortStationsByAfvOrder,
     state.updateChannel,
     state.setShowExpandedRxInfo,
     state.setTransparentMiniMode,
     state.setPendingRestart,
     state.setRadioToMaxVolumeOnTX,
+    state.setSortStationsByAfvOrder,
     state.setUpdateChannel
   ]);
   const [isMicTesting, setIsMicTesting] = useState(false);
@@ -98,6 +103,7 @@ const SettingsModal: React.FC<SettingsModalProps> = ({ closeModal }) => {
         setTransparentMiniMode(config.transparentMiniMode);
         setLocalTransparentMiniMode(config.transparentMiniMode);
         setRadioToMaxVolumeOnTX(config.radioToMaxVolumeOnTx);
+        setSortStationsByAfvOrder(config.sortStationsByAfvOrder);
         setPttReleaseSoundEnabled(config.pttReleaseSoundEnabled);
         setLoopbackEnabled(config.loopbackEnabled);
         setLoopbackTarget(config.loopbackTarget);
@@ -242,6 +248,16 @@ const SettingsModal: React.FC<SettingsModalProps> = ({ closeModal }) => {
       window.api.setRadioToMaxVolumeOnTX(false);
       setRadioToMaxVolumeOnTX(false);
     }
+    setChangesSaved(SaveStatus.Saved);
+  };
+
+  const handleStationSortingChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
+    setChangesSaved(SaveStatus.Saving);
+    const enabled = e.target.value === 'true';
+    window.api.setSortStationsByAfvOrder(enabled);
+    setSortStationsByAfvOrder(enabled);
+    setConfig({ ...config, sortStationsByAfvOrder: enabled });
+    useRadioState.getState().sortRadios(useSessionStore.getState().getStationCallsign(), enabled);
     setChangesSaved(SaveStatus.Saved);
   };
 
@@ -582,6 +598,15 @@ const SettingsModal: React.FC<SettingsModalProps> = ({ closeModal }) => {
                         <option value="0">Schmid ED-137B</option>
                         <option value="1">Rockwell Collins 2100</option>
                         <option value="2">Garex 220</option>
+                      </select>
+                      <label className="mt-2">Station sorting</label>
+                      <select
+                        className="form-control mt-1"
+                        value={sortStationsByAfvOrder.toString()}
+                        onChange={handleStationSortingChange}
+                      >
+                        <option value="false">Position type</option>
+                        <option value="true">AFV editor order</option>
                       </select>
                       <label className="mt-2">PTT release click sound</label>
                       <select

--- a/src/renderer/src/helpers/RadioHelper.ts
+++ b/src/renderer/src/helpers/RadioHelper.ts
@@ -4,22 +4,26 @@ const endStations = ['GUARD', 'ADVISORY'];
 
 /**
  * Compares two radios to determine sort order. The currently connected station
- * will always sort to the front of the list. The remaining stations will sort
- * by station name (e.g. "LFPG"), then by position (e.g. "TWR"), then by
- * sub-position (e.g. "N")
+ * will always sort to the front of the list. When enabled, AFV-ordered stations
+ * will follow in the order defined by the AFV editor. The remaining stations
+ * sort by station name (e.g. "LFPG"), then by position (e.g. "TWR"), then by
+ * sub-position (e.g. "N").
  * @param a The first radio to compare
  * @param b The second radio to compare
  * @param connectedStationCallsign The callsign for the connected station
+ * @param sortByAfvOrder Whether AFV editor order should take priority
  * @returns -1 if a comes before b. 1 if b comes before a.
  */
 export const radioCompare = (
   a: RadioType,
   b: RadioType,
-  connectedStationCallsign: string
+  connectedStationCallsign: string,
+  sortByAfvOrder: boolean
 ): number => {
-  // The connected station always get sorted to the front of the list.
-  if (a.callsign === connectedStationCallsign) return -1;
-  if (b.callsign === connectedStationCallsign) return 1;
+  // The connected station always gets sorted to the front of the list.
+  const aIsConnectedStation = a.callsign === connectedStationCallsign;
+  const bIsConnectedStation = b.callsign === connectedStationCallsign;
+  if (aIsConnectedStation !== bIsConnectedStation) return aIsConnectedStation ? -1 : 1;
 
   // Always push "GUARD" and "ADVISORY" to the end of the list
   const aIsEndStation = endStations.includes(a.station);
@@ -27,6 +31,19 @@ export const radioCompare = (
 
   if (aIsEndStation && !bIsEndStation) return 1;
   if (!aIsEndStation && bIsEndStation) return -1;
+
+  // Keep VCCS stations in the order defined by the AFV editor. Ordered stations
+  // take priority over manually added or legacy stations without an AFV order.
+  if (sortByAfvOrder) {
+    if (a.afvOrder !== undefined && b.afvOrder !== undefined) {
+      const afvOrderComparison = a.afvOrder - b.afvOrder;
+      if (afvOrderComparison !== 0) return afvOrderComparison;
+    } else if (a.afvOrder !== undefined) {
+      return -1;
+    } else if (b.afvOrder !== undefined) {
+      return 1;
+    }
+  }
 
   // The station name takes sort priority
   const stationComparison = a.station.localeCompare(b.station);

--- a/src/renderer/src/interfaces/IPCInterface.ts
+++ b/src/renderer/src/interfaces/IPCInterface.ts
@@ -25,6 +25,7 @@ class IPCInterface {
         utilStoreState.setShowExpandedRxInfo(config.showExpandedRx);
         utilStoreState.setTransparentMiniMode(config.transparentMiniMode);
         utilStoreState.setRadioToMaxVolumeOnTX(config.radioToMaxVolumeOnTx);
+        utilStoreState.setSortStationsByAfvOrder(config.sortStationsByAfvOrder);
       })
       .catch((err: unknown) => {
         window.api.log.error(err as string);

--- a/src/renderer/src/interfaces/Station.ts
+++ b/src/renderer/src/interfaces/Station.ts
@@ -2,4 +2,5 @@ export interface Station {
   name: string;
   frequency: number;
   frequencyAlias?: number;
+  afvOrder?: number;
 }

--- a/src/renderer/src/store/radioStore.ts
+++ b/src/renderer/src/store/radioStore.ts
@@ -4,10 +4,12 @@ import { radioCompare } from '../helpers/RadioHelper';
 import { getCallsignParts } from '../helpers/CallsignHelper';
 import { GuardFrequency, UnicomFrequency } from '../../../shared/common';
 import { Station } from '@renderer/interfaces/Station';
+import useUtilStore from './utilStore';
 
 export interface RadioType {
   frequency: number;
   frequencyAlias?: number;
+  afvOrder?: number;
   humanFrequency: string;
   humanFrequencyAlias?: string;
   callsign: string;
@@ -65,6 +67,7 @@ interface RadioState {
   clearRadiosToBeDeleted: () => void;
   getRadioByFrequency: (frequency: number) => RadioType | undefined;
   setShowingUnicomBar: (value: boolean) => void;
+  sortRadios: (stationCallsign: string, sortByAfvOrder: boolean) => void;
 }
 
 // eslint-disable-next-line @typescript-eslint/no-extraneous-class
@@ -99,6 +102,11 @@ const useRadioState = create<RadioState>((set, get) => ({
   setShowingUnicomBar: (value) => {
     set(() => ({
       showingUnicomBar: value
+    }));
+  },
+  sortRadios: (stationCallsign, sortByAfvOrder) => {
+    set((state) => ({
+      radios: [...state.radios].sort((a, b) => radioCompare(a, b, stationCallsign, sortByAfvOrder))
     }));
   },
   addRadio: (frequency, callsign, stationCallsign) => {
@@ -137,11 +145,13 @@ const useRadioState = create<RadioState>((set, get) => ({
           isOutputMuted: false,
           lastReceivedCallsigns: []
         }
-      ].sort((a, b) => radioCompare(a, b, stationCallsign))
+      ].sort((a, b) =>
+        radioCompare(a, b, stationCallsign, useUtilStore.getState().sortStationsByAfvOrder)
+      )
     }));
   },
   addRadioByStation: (radio: Station, stationCallsign: string) => {
-    const { frequency, name: callsign, frequencyAlias } = radio;
+    const { frequency, name: callsign, frequencyAlias, afvOrder } = radio;
 
     if (RadioHelper.doesRadioExist(useRadioState.getState().radios, frequency)) {
       if (frequency !== UnicomFrequency && frequency !== GuardFrequency) {
@@ -164,6 +174,7 @@ const useRadioState = create<RadioState>((set, get) => ({
         {
           frequency,
           frequencyAlias,
+          afvOrder,
           humanFrequencyAlias,
           humanFrequency: RadioHelper.convertHzToMhzString(frequency),
           callsign,
@@ -184,7 +195,9 @@ const useRadioState = create<RadioState>((set, get) => ({
           isOutputMuted: false,
           lastReceivedCallsigns: []
         }
-      ].sort((a, b) => radioCompare(a, b, stationCallsign))
+      ].sort((a, b) =>
+        radioCompare(a, b, stationCallsign, useUtilStore.getState().sortStationsByAfvOrder)
+      )
     }));
   },
   addOrRemoveRadioToBeDeleted: (radio) => {

--- a/src/renderer/src/store/utilStore.ts
+++ b/src/renderer/src/store/utilStore.ts
@@ -15,6 +15,7 @@ interface UtilStore {
   pendingRestart: boolean;
   transparentMiniMode: boolean;
   radioToMaxVolumeOnTX: boolean;
+  sortStationsByAfvOrder: boolean;
   updateChannel: string;
   time: Date;
   setIsEditMode: (isEditMode: boolean) => void;
@@ -30,6 +31,7 @@ interface UtilStore {
   setTransparentMiniMode: (transparentMiniMode: boolean) => void;
   setPendingRestart: (pendingRestart: boolean) => void;
   setRadioToMaxVolumeOnTX: (maxVolume: boolean) => void;
+  setSortStationsByAfvOrder: (sortByAfvOrder: boolean) => void;
   setTime: (time: Date) => void;
   setUpdateChannel: (updateChannel: string) => void;
 }
@@ -49,6 +51,7 @@ const useUtilStore = create<UtilStore>((set) => ({
   transparentMiniMode: false,
   pendingRestart: false,
   radioToMaxVolumeOnTX: false,
+  sortStationsByAfvOrder: false,
   time: new Date(),
   updateChannel: 'stable',
   setIsEditMode: (isEditMode: boolean) => {
@@ -92,6 +95,9 @@ const useUtilStore = create<UtilStore>((set) => ({
   },
   setRadioToMaxVolumeOnTX: (maxVolume: boolean): void => {
     set({ radioToMaxVolumeOnTX: maxVolume });
+  },
+  setSortStationsByAfvOrder: (sortByAfvOrder: boolean): void => {
+    set({ sortStationsByAfvOrder: sortByAfvOrder });
   },
   setUpdateChannel: (updateChannel: string): void => {
     if (updateChannel !== 'stable' && updateChannel !== 'beta') return;

--- a/src/shared/config.type.ts
+++ b/src/shared/config.type.ts
@@ -24,6 +24,7 @@ export interface Configuration {
   transparentMiniMode: boolean;
 
   radioToMaxVolumeOnTx: boolean;
+  sortStationsByAfvOrder: boolean;
 
   pttReleaseSoundEnabled: boolean;
 


### PR DESCRIPTION
## Summary

- add a persisted **Station sorting** option under Radio settings
- retain the current position-based ordering as the default
- allow users to opt into the order configured in the AFV editor
- re-sort currently displayed radios immediately when the option changes
- carry AFV VCCS order metadata from the native event through the backend and renderer

## Why

AFV returns VCCS stations in editor order, but AFV-native previously stored the response in a callsign-keyed `std::map`, losing that sequence. TrackAudio therefore always fell back to its callsign/position sorting even when a facility had deliberately arranged commonly coupled frequencies at the top of its VCCS configuration.

The associated AFV-native change records the original array position before map insertion: [pierr3/afv-native#23](https://github.com/pierr3/afv-native/pull/23).

Closes #343.

## Behavior

The new setting defaults to **Position type**, preserving existing behavior. Selecting **AFV editor order** applies the recorded VCCS order while keeping these existing rules:

- the connected or requested primary station remains first
- GUARD and ADVISORY remain last
- manually added, legacy, or otherwise unordered stations retain the existing callsign/position/sub-position fallback

The setting is persisted through the existing configuration manager. Existing configurations receive the default value without requiring a breaking settings migration.

## Validation

- native Windows Release build completed successfully
- Node and renderer TypeScript checks passed
- ESLint passed
- Prettier check passed
- Electron main, preload, and renderer production build passed
- behavior was manually validated with the EKCH VCCS ordering example

The production build still reports the repository's existing Sass deprecation warnings; this change does not add or modify Sass.
