### PR TITLE
Fix auto-disconnect when leaving the network

### DIFF
--- a/backend/include/RemoteData.hpp
+++ b/backend/include/RemoteData.hpp
@@ -4,6 +4,7 @@
 #include <absl/strings/str_split.h>
 #include <cstddef>
 #include <mutex>
+#include <optional>
 #include <string>
 
 #define WIN32_LEAN_AND_MEAN
@@ -36,7 +37,11 @@ public:
 protected:
     void onTimer(Poco::Timer& /*timer*/);
 
-    std::string getSlurperData(const std::string& cid);
+    // Returns nullopt when the slurper could not be reached, so that an outage
+    // is not mistaken for the user having gone offline. A returned value is
+    // authoritative even when empty: an empty body means the CID has no active
+    // connection, which is a genuine disconnect.
+    std::optional<std::string> getSlurperData(const std::string& cid);
 
     // NOLINTNEXTLINE
     bool parseSlurper(const std::string& sluper_data);

--- a/backend/src/RemoteData.cpp
+++ b/backend/src/RemoteData.cpp
@@ -33,17 +33,19 @@ void RemoteData::onTimer(Poco::Timer& /*timer*/)
     }
     try {
         auto slurperData = getSlurperData(cid);
-        if (slurperData.empty()) {
-            // getSlurperData handles grace period and unavailability notifications
-            // internally. Never feed empty data into parseSlurper — it returns false
-            // which causes updateSessionStatus to disconnect the voice session.
+        if (!slurperData.has_value()) {
+            // The slurper could not be reached. getSlurperData handles the grace
+            // period and unavailability notifications internally; leave the session
+            // state untouched so an outage is not treated as a disconnect.
             return;
         }
         // Successful fetch — reset grace period
         enteredSlurperGracePeriod = false;
-        // Re-acquire session lock for parsing and updating session state
+        // Re-acquire session lock for parsing and updating session state.
+        // An empty body is authoritative: it means the CID has no active
+        // connection, so the session must be torn down.
         std::lock_guard<std::mutex> sessionLock(UserSession::mtx);
-        auto isConnected = parseSlurper(slurperData);
+        auto isConnected = parseSlurper(*slurperData);
         updateSessionStatus(previousCallsign, isConnected);
     } catch (const std::exception& ex) {
         RemoteDataStatus::isSlurperAvailable = false;
@@ -59,10 +61,10 @@ void RemoteData::onTimer(Poco::Timer& /*timer*/)
 }
 
 // NOLINTNEXTLINE(readability-function-cognitive-complexity)
-std::string RemoteData::getSlurperData(const std::string& cid)
+std::optional<std::string> RemoteData::getSlurperData(const std::string& cid)
 {
     if (cid.empty()) {
-        return "";
+        return std::nullopt;
     }
 
     httplib::Client slurperCli(SLURPER_BASE_URL);
@@ -76,13 +78,13 @@ std::string RemoteData::getSlurperData(const std::string& cid)
         if (!enteredSlurperGracePeriod) {
             enteredSlurperGracePeriod = true;
             PLOG_ERROR << "Cannot get data from the slurper. Giving it one more try";
-            return "";
+            return std::nullopt;
         }
         RemoteDataStatus::isSlurperAvailable = false;
         PLOG_ERROR << "Cannot get data from the slurper. Object is null.";
         notifyUserOfSlurperUnavalability();
         enteredSlurperGracePeriod = false;
-        return "";
+        return std::nullopt;
     }
 
     if (res->status != httplib::StatusCode::OK_200) {
@@ -90,14 +92,14 @@ std::string RemoteData::getSlurperData(const std::string& cid)
             enteredSlurperGracePeriod = true;
             PLOG_ERROR << "Slurper returned an HTTP error " << res->status
                        << ". Giving it one more try";
-            return "";
+            return std::nullopt;
         }
 
         RemoteDataStatus::isSlurperAvailable = false;
         PLOG_ERROR << "Slurper returned an HTTP error " << res->status;
         notifyUserOfSlurperUnavalability();
         enteredSlurperGracePeriod = false;
-        return "";
+        return std::nullopt;
     }
 
     if (!RemoteDataStatus::isSlurperAvailable) {
@@ -225,11 +227,13 @@ void RemoteData::updateSessionStatus(const std::string& previousCallsign, bool i
         return;
     } else {
         if (mClient->IsVoiceConnected()) {
+            // Notify before disconnecting: Disconnect() tears down the audio device
+            // synchronously, and the error sound is gated on audio still running.
+            NapiHelpers::sendErrorToElectron("No active connection found in the slurper data, "
+                                             "you have been disconnected.");
             mClient->Disconnect();
             PLOG_INFO << "Disconnected from the network because no active connection was found in "
                          "the slurper data.";
-            NapiHelpers::sendErrorToElectron("No active connection found in the slurper data, "
-                                             "you have been disconnected.");
         }
 
         UserSession::isConnectedToTheNetwork = false;


### PR DESCRIPTION
Regression introduced in `a6f04c4` (2026-04-13, "Update afv native, fixes"), I am not sure what you were trying to fix in the slurper parser.
TL:DR: slurper failure and disconnect both produced empty data, which was caught by the parser and immediately returned, good logic for a slurper outage but wrong for the disconnect event. Fix is to use optional result with nullopt being connection failure, while empty resolve to disconnected.

Detailed Claude output:
getSlurperData() returned an empty string both when the slurper could not be reached and when it replied 200 with no record for the CID. Since a6f04c4 onTimer() skipped the session update on any empty response, so the two cases became indistinguishable and leaving the network no longer tore down the voice session.

The consequences were that updateSessionStatus() was never reached with isConnected false, so Disconnect() never ran, isConnectedToTheNetwork and callsign stayed at their last connected values, and Connect() then refused a reconnect because IsVoiceConnected() was still true. The disconnect notification was not raised either, so no error was surfaced.

Return std::optional so the two cases can be told apart. nullopt means the slurper could not be reached and the session state is left alone, which preserves the grace period that guard was added for. A returned value is authoritative even when empty, since an empty body means the CID has no active connection.

Also raise the disconnect notification before Disconnect(), which tears down the audio device synchronously while the error sound is gated on audio still running.